### PR TITLE
[sailfishos][gecko] Patch rust components to build on arm. JB#54221

### DIFF
--- a/rpm/0034-sailfishos-gecko-Disable-link-time-optimization-for-.patch
+++ b/rpm/0034-sailfishos-gecko-Disable-link-time-optimization-for-.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pavel Tumakaev <p.tumakaev@omprussia.ru>
+Date: Tue, 13 Apr 2021 13:37:00 +0300
+Subject: [PATCH] [sailfishos][gecko] Disable link time optimization for rust
+ components
+
+---
+ config/makefiles/rust.mk | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/config/makefiles/rust.mk b/config/makefiles/rust.mk
+index 8a4782cc2c0f..530ae44e3d8b 100644
+--- a/config/makefiles/rust.mk
++++ b/config/makefiles/rust.mk
+@@ -55,18 +55,18 @@ endif
+ # invocation (i.e., only the top-level crate, not its dependencies).
+ cargo_rustc_flags = $(CARGO_RUSTCFLAGS)
+ ifndef DEVELOPER_OPTIONS
+-ifndef MOZ_DEBUG_RUST
++#ifndef MOZ_DEBUG_RUST
+ # Enable link-time optimization for release builds, but not when linking
+ # gkrust_gtest.
+-ifeq (,$(findstring gkrust_gtest,$(RUST_LIBRARY_FILE)))
+-cargo_rustc_flags += -Clto
+-endif
++#ifeq (,$(findstring gkrust_gtest,$(RUST_LIBRARY_FILE)))
++#cargo_rustc_flags += -Clto
++#endif
+ # Versions of rust >= 1.45 need -Cembed-bitcode=yes for all crates when
+ # using -Clto.
+-ifeq (,$(filter 1.38.% 1.39.% 1.40.% 1.41.% 1.42.% 1.43.% 1.44.%,$(RUSTC_VERSION)))
+-RUSTFLAGS += -Cembed-bitcode=yes
+-endif
+-endif
++#ifeq (,$(filter 1.38.% 1.39.% 1.40.% 1.41.% 1.42.% 1.43.% 1.44.%,$(RUSTC_VERSION)))
++#RUSTFLAGS += -Cembed-bitcode=yes
++#endif
++#endif
+ endif
+ 
+ ifdef CARGO_INCREMENTAL
+-- 
+2.25.1
+

--- a/rpm/0035-sailfishos-gecko-Patch-libloading-to-build-on-arm.-J.patch
+++ b/rpm/0035-sailfishos-gecko-Patch-libloading-to-build-on-arm.-J.patch
@@ -1,0 +1,113 @@
+From 40ff77a64ff1177a67d59b031263f00d8489adbe Mon Sep 17 00:00:00 2001
+From: David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
+Date: Fri, 30 Jul 2021 08:10:23 +0000
+Subject: [PATCH] [sailfishos][gecko] Patch libloading to build on arm.
+ JB#54221
+
+This patch overrides the default build step using cc::Build to force the
+right tool to be used (host-gcc) and allow libloading to be compiled and
+linked against.
+---
+ .../rust/libloading/.cargo-checksum.json      |  2 +-
+ third_party/rust/libloading/build.rs          | 71 ++++++++++++++++++-
+ 2 files changed, 69 insertions(+), 4 deletions(-)
+
+diff --git a/third_party/rust/libloading/.cargo-checksum.json b/third_party/rust/libloading/.cargo-checksum.json
+index 6a7f51d63560..e3b509fd222b 100644
+--- a/third_party/rust/libloading/.cargo-checksum.json
++++ b/third_party/rust/libloading/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.toml":"9110a58fe827a68e5df22f8d38e4beab38c259724942e868c5ae3debc2f0ebae","LICENSE":"b29f8b01452350c20dd1af16ef83b598fea3053578ccc1c7a0ef40e57be2620f","README.mkd":"b4cd83f110d01dc5aa8fcaf3da34bdbe1478efdba767d73abc14d4d87e4775fa","appveyor.yml":"8382c7f1769f6cf78029a221058c4d73f35a48308b5dfc38d875facabec1c139","build.rs":"d8f7fce1b459d117cd48d85ba3643124bd09657a0df9e0e90a1fd997decff741","src/changelog.rs":"e8a769578ebe2db81055b131ce12fa14c9ad0f21a79035748f244e5b347b2ada","src/lib.rs":"0cc0f6b42c98c14183dea2bc9deaf5aa574fabbe61081fe3339d74430f25fc12","src/os/mod.rs":"51d733e5522dacd6069642ad66aa6d7acf6c82950c934eb040e8dfd112e6d610","src/os/unix/global_static.c":"b1096dedf7d4aed5c28b658fc917f6603339ffd92390c84e25cb543bdc9460ac","src/os/unix/mod.rs":"9a84c15d0b9e5125a6ca086854a0e18884cb6c04cea54f47f1a44243e69335c2","src/os/windows/mod.rs":"c0ee0068a0564d64b7f3d3053d799492693c34571a935fc893a41a62a86fccdd","src/test_helpers.rs":"3a55052e8cd5231e97d9282b43398c2f144c57ced2d2df64bde7f482f5c778e7","src/util.rs":"5d1d3fcf7e5e9dc67df0dbf91332c5e3f5875e90c8f80ada5cfad0bc3c402d7e","tests/functions.rs":"4633f3673db6a5b3623ea8927b13314c25502c9fbb63bb17a5a35650ea489012","tests/markers.rs":"8e9c1b883404d9190e4f23ed39b3d6cbbccb3a07883f733b04aed4357b9c6aca","tests/nagisa32.dll":"5c69b2bd9c8a6ad04165c221075fc9fade1dd66ca697399ace528a5a62328e36","tests/nagisa64.dll":"e20b95e3036f3289421abd100760874d4f455afd33c3b5b64fec56b191f7d477","tests/windows.rs":"7711dfe19062d91356cd127546542b1b6e13aeef76ad3098f32c8a6ae319b66a"},"package":"f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"}
+\ No newline at end of file
++{"files":{"Cargo.toml":"9110a58fe827a68e5df22f8d38e4beab38c259724942e868c5ae3debc2f0ebae","LICENSE":"b29f8b01452350c20dd1af16ef83b598fea3053578ccc1c7a0ef40e57be2620f","README.mkd":"b4cd83f110d01dc5aa8fcaf3da34bdbe1478efdba767d73abc14d4d87e4775fa","appveyor.yml":"8382c7f1769f6cf78029a221058c4d73f35a48308b5dfc38d875facabec1c139","build.rs":"8bf389a87118c2662388acf4e769504c5c3b89e627ed869400536cfcdc5e0b33","src/changelog.rs":"e8a769578ebe2db81055b131ce12fa14c9ad0f21a79035748f244e5b347b2ada","src/lib.rs":"0cc0f6b42c98c14183dea2bc9deaf5aa574fabbe61081fe3339d74430f25fc12","src/os/mod.rs":"51d733e5522dacd6069642ad66aa6d7acf6c82950c934eb040e8dfd112e6d610","src/os/unix/global_static.c":"b1096dedf7d4aed5c28b658fc917f6603339ffd92390c84e25cb543bdc9460ac","src/os/unix/mod.rs":"9a84c15d0b9e5125a6ca086854a0e18884cb6c04cea54f47f1a44243e69335c2","src/os/windows/mod.rs":"c0ee0068a0564d64b7f3d3053d799492693c34571a935fc893a41a62a86fccdd","src/test_helpers.rs":"3a55052e8cd5231e97d9282b43398c2f144c57ced2d2df64bde7f482f5c778e7","src/util.rs":"5d1d3fcf7e5e9dc67df0dbf91332c5e3f5875e90c8f80ada5cfad0bc3c402d7e","tests/functions.rs":"4633f3673db6a5b3623ea8927b13314c25502c9fbb63bb17a5a35650ea489012","tests/markers.rs":"8e9c1b883404d9190e4f23ed39b3d6cbbccb3a07883f733b04aed4357b9c6aca","tests/nagisa32.dll":"5c69b2bd9c8a6ad04165c221075fc9fade1dd66ca697399ace528a5a62328e36","tests/nagisa64.dll":"e20b95e3036f3289421abd100760874d4f455afd33c3b5b64fec56b191f7d477","tests/windows.rs":"7711dfe19062d91356cd127546542b1b6e13aeef76ad3098f32c8a6ae319b66a"},"package":"f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"}
+diff --git a/third_party/rust/libloading/build.rs b/third_party/rust/libloading/build.rs
+index fc380a7450a0..7ee0617c0108 100644
+--- a/third_party/rust/libloading/build.rs
++++ b/third_party/rust/libloading/build.rs
+@@ -2,6 +2,26 @@ extern crate cc;
+ 
+ use std::io::Write;
+ use std::env;
++use std::process::Command;
++use std::path::Path;
++
++fn is_486_target() -> bool {
++    let mut is_486_target = false;
++    match env::var("TARGET") {
++        Ok(val) => is_486_target = val == "i686-unknown-linux-gnu",
++        Err(e) => {},
++    }
++    return is_486_target;
++}
++
++fn is_486_sb2() -> bool {
++    let mut is_486_sb2 = false;
++    match env::var("SB2_TARGET") {
++        Ok(val) => is_486_sb2 = val == "i686-unknown-linux-gnu",
++        Err(e) => {},
++    }
++    return is_486_sb2;
++}
+ 
+ fn main(){
+     let target_os = env::var("CARGO_CFG_TARGET_OS");
+@@ -25,8 +45,53 @@ fn main(){
+         }
+     }
+     if is_unix {
+-        cc::Build::new()
+-            .file("src/os/unix/global_static.c")
+-            .compile("global_static");
++        // Comment out to control the override behaviour
++        let override_compiler = is_486_target() && !is_486_sb2();
++        //let override_compiler = false
++        //let override_compiler = true;
++
++        if !override_compiler {
++            // The original standard cc command which we're overriding
++            // cc replaced with clang to avoid warnings (treated as errors)
++            // about -Qunused-arguments and -fexperimental-new-pass-manager
++            // being unrecognised
++            cc::Build::new()
++                .compiler("clang")
++                .file("src/os/unix/global_static.c")
++                .compile("global_static");
++        }
++        else {
++            // The following steps mimic the steps that cc::Build would perform otherwise
++            let out_dir = env::var("OUT_DIR").unwrap();
++
++            // Ensure we have an output directory
++            Command::new("mkdir")
++                .arg("-p")
++                .arg(&out_dir)
++                .status()
++                .unwrap();
++
++            // Compile global_static.c into global_static.o
++            Command::new("host-gcc")
++                .args(&["-O0", "-ffunction-sections", "-fdata-sections", "-fPIC", "-g", "-fno-omit-frame-pointer", "-m32", "-march=i686", "-Wall", "-Wextra", "-o"])
++                //.args(&["-O0", "-ffunction-sections", "-fdata-sections", "-fPIC", "-g", "-fno-omit-frame-pointer", "-m64", "-Wall", "-Wextra", "-o"])
++                .arg(&format!("{}/global_static.o", out_dir))
++                .args(&["-c", "src/os/unix/global_static.c"])
++                .status()
++                .unwrap();
++
++            // Package up the result into a library
++            Command::new("ar")
++                .args(&["crus", "libglobal_static.a", "global_static.o"])
++                .current_dir(&Path::new(&out_dir))
++                .status()
++                .unwrap();
++
++            // Ensure cargo knows where to find the results
++            println!("cargo:rustc-link-search=native={}", out_dir);
++            println!("cargo:rustc-link-lib=static=global_static");
++            // Ensure changes propagate
++            println!("cargo:rerun-if-changed=src/os/unix/global_static.c");
++        }
+     }
+ }
+-- 
+2.17.1
+

--- a/rpm/0036-sailfishos-gecko-Skip-min_libclang_version-test-duri.patch
+++ b/rpm/0036-sailfishos-gecko-Skip-min_libclang_version-test-duri.patch
@@ -1,0 +1,29 @@
+From ba7c0f0b47f6511b0e6155a38710336f1696cb82 Mon Sep 17 00:00:00 2001
+From: David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
+Date: Wed, 4 Aug 2021 20:07:37 +0000
+Subject: [PATCH] [sailfishos][gecko] Skip min_libclang_version test during
+ configuration
+
+Removes the check for the correct libclang.so version, since on arm
+targets this requires an arm library, while with the build process
+running on the host architecture, libclang must match the host's
+processor architecture.
+---
+ build/moz.configure/bindgen.configure | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/build/moz.configure/bindgen.configure b/build/moz.configure/bindgen.configure
+index 9b45948ffc8f..f829619dfe10 100644
+--- a/build/moz.configure/bindgen.configure
++++ b/build/moz.configure/bindgen.configure
+@@ -223,6 +223,7 @@ def bindgen_config_paths(clang, libclang, build_project):
+ @imports(_from='ctypes', _import='CDLL')
+ @imports(_from='textwrap', _import='dedent')
+ def min_libclang_version(libclang):
++    return True
+     try:
+         lib = CDLL(libclang)
+         # We want at least 4.0. The API we test below is enough for that.
+-- 
+2.17.1
+

--- a/rpm/0037-sailfishos-gecko-Patch-glslopt-to-build-on-arm.patch
+++ b/rpm/0037-sailfishos-gecko-Patch-glslopt-to-build-on-arm.patch
@@ -1,0 +1,679 @@
+From 2cfb757841c688073d305e61c56b54062b120c54 Mon Sep 17 00:00:00 2001
+From: David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
+Date: Wed, 4 Aug 2021 20:43:40 +0000
+Subject: [PATCH] [sailfishos][gecko] Patch glslopt to build on arm
+
+This patch overrides the default build step using cc::Build to force the
+right tools to be used (host-gcc and host-g++) and allow glslopt to be
+compiled and linked against.
+---
+ third_party/rust/glslopt/.cargo-checksum.json |   2 +-
+ third_party/rust/glslopt/build.rs             | 632 +++++++++++++-----
+ 2 files changed, 467 insertions(+), 167 deletions(-)
+
+diff --git a/third_party/rust/glslopt/.cargo-checksum.json b/third_party/rust/glslopt/.cargo-checksum.json
+index 15adacfeca57..3fb704d7c0b7 100644
+--- a/third_party/rust/glslopt/.cargo-checksum.json
++++ b/third_party/rust/glslopt/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.toml":"ca1e2ac475b5a6365f6c75ce25420cf6c770d376399b27adbeccf3c73cbdc12e","build.rs":"4d89c2e7ce8d5ac7dd03db7beba6a1e8567e70afa77e1d04c657db2201a03abb","glsl-optimizer/CMakeLists.txt":"c7c98d4bd7d0996152883f5f71f1eb19cf3df5e2dd62069bddef430e5d5aa7f3","glsl-optimizer/README.md":"b18eef11a92d267d88a937b1154f7670ee433c730b102fdf7e2da0b02722b146","glsl-optimizer/contrib/glslopt/Main.cpp":"14ba213210c62e234b8d9b0052105fed28eedd83d535ebe85acc10bda7322dd4","glsl-optimizer/contrib/glslopt/Readme":"65d2a6f1aa1dc61e903e090cdade027abad33e02e7c9c81e07dc80508acadec4","glsl-optimizer/generateParsers.sh":"878a97db5d3b69eb3b4c3a95780763b373cfcc0c02e0b28894f162dbbd1b8848","glsl-optimizer/include/GL/gl.h":"1989b51365b6d7d0c48ff6e8b181ef75e2cdf71bfb1626b1cc4362e2f54854a3","glsl-optimizer/include/GL/glext.h":"2ac3681045a35a2194a81a960cad395c04bef1c8a20ef46b799fb24af3ec5f70","glsl-optimizer/include/KHR/khrplatform.h":"1448141a0c054d7f46edfb63f4fe6c203acf9591974049481c32442fb03fd6ed","glsl-optimizer/include/c11/threads.h":"56e9e592b28df19f0db432125223cb3eb5c0c1f960c22db96a15692e14776337","glsl-optimizer/include/c11/threads_posix.h":"f8ad2b69fa472e332b50572c1b2dcc1c8a0fa783a1199aad245398d3df421b4b","glsl-optimizer/include/c11/threads_win32.h":"95bf19d7fc14d328a016889afd583e4c49c050a93bcfb114bd2e9130a4532488","glsl-optimizer/include/c11_compat.h":"103fedb48f658d36cb416c9c9e5ea4d70dff181aab551fcb1028107d098ffa3e","glsl-optimizer/include/c99_alloca.h":"96ffde34c6cabd17e41df0ea8b79b034ce8f406a60ef58fe8f068af406d8b194","glsl-optimizer/include/c99_compat.h":"aafad02f1ea90a7857636913ea21617a0fcd6197256dcfc6dd97bb3410ba892e","glsl-optimizer/include/c99_math.h":"9730d800899f1e3a605f58e19451cd016385024a05a5300e1ed9c7aeeb1c3463","glsl-optimizer/include/no_extern_c.h":"40069dbb6dd2843658d442f926e609c7799b9c296046a90b62b570774fd618f5","glsl-optimizer/license.txt":"e26a745226f4a46b3ca00ffbe8be18507362189a2863d04b4f563ba176a9a836","glsl-optimizer/src/compiler/builtin_type_macros.h":"5b4fc4d4da7b07f997b6eb569e37db79fa0735286575ef1fab08d419e76776ff","glsl-optimizer/src/compiler/glsl/README":"66a1c12ed7ba0fb63c55ef4559556d2430b89a394d4a8d057f861b8ee1b42608","glsl-optimizer/src/compiler/glsl/TODO":"dd3b7a098e6f9c85ca8c99ce6dea49d65bb75d4cea243b917f29e4ad2c974603","glsl-optimizer/src/compiler/glsl/ast.h":"97fcbc54c28ad4f73dcbf437bcaaf7466344f05578ed72de6786f6a69897bd4e","glsl-optimizer/src/compiler/glsl/ast_array_index.cpp":"92b4d501f33e0544c00d14e4f8837753afd916c2b42e076ccc95c9e8fc37ba94","glsl-optimizer/src/compiler/glsl/ast_expr.cpp":"afd712a7b1beb2b633888f4a0911b0a8e4ae5eb5ab9c1e3f247d518cdaaa56d6","glsl-optimizer/src/compiler/glsl/ast_function.cpp":"67ec8e47a00773c9048778179c4e32e57b301146a433559a2aec008698f6ca8e","glsl-optimizer/src/compiler/glsl/ast_to_hir.cpp":"4f5fd3b906c0cf79e608b28619e900dbc49ad35e04ccf43e809798d8145d13de","glsl-optimizer/src/compiler/glsl/ast_type.cpp":"8eb790b24b26dfb72bdc333744b566c26d8464c5d47d20eae659461f5c4899f7","glsl-optimizer/src/compiler/glsl/builtin_functions.cpp":"9b153e8e2b8e3721a0e0325507c1745afbe7b0c56c2f3b6997dd74197cb889c8","glsl-optimizer/src/compiler/glsl/builtin_functions.h":"a37cad7ed09b522c5b8bec7b80115a36846e7ba6e0874a2a858e32f7f202c665","glsl-optimizer/src/compiler/glsl/builtin_int64.h":"619def6f3aebf180da3944ef08f159ab12a58b24767e41d8b985ac37ded54d62","glsl-optimizer/src/compiler/glsl/builtin_types.cpp":"afec060b62d6f3b00bfbf94e9fa5f96341ce096c128d1eef322791e6ed9cea4d","glsl-optimizer/src/compiler/glsl/builtin_variables.cpp":"8f033c7a6f3f9a4ca6dac9409cd668e30cc7d618dda6e3aa9451465f9e9f587d","glsl-optimizer/src/compiler/glsl/float64.glsl":"fc60780e102a54d97d091518a3bca12159ff4e23c2fc66a5366b359dfaa9e83b","glsl-optimizer/src/compiler/glsl/generate_ir.cpp":"e5f0175370a0d07f93c48d3f0f1b8233d12c64a7b02de02dcc753ef7b398ef0f","glsl-optimizer/src/compiler/glsl/glcpp/README":"a0332a1b221d047e9cce5181a64d4ac4056046fd878360ec8ae3a7b1e062bcff","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-lex.c":"2d179879b1ffe84f58875eee5b0c19b6bae9c973b0c48e6bcd99978f2f501c80","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-lex.l":"e4c5744c837200dafd7c15a912d13f650308ea552454d4fa67271bc0a5bde118","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.c":"36970dd12f54ed02102fbd57962f00710a70a2effccbcbd6caec7625be486e7b","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.h":"5a7158375ecbf6ac8320466c33d534acbe9e60669f5e1908431851dc1ed1f57f","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.y":"4c9ee9e1fe4e9b96407631e7ec725c96713d1efb1c798538b5e4d02fc8191b9e","glsl-optimizer/src/compiler/glsl/glcpp/glcpp.c":"37ed294403c2abfd17fd999d1ae8d11b170e5e9c878979fefac74a31195c96b0","glsl-optimizer/src/compiler/glsl/glcpp/glcpp.h":"85ac8b444bcbd0822b66448a1da407b6ae5467b649f5afaf5c58325bd7569468","glsl-optimizer/src/compiler/glsl/glcpp/pp.c":"a52d94f1bcb3fb2747a95709c4a77c25de7eea8354d2b83bb18efd96976a4473","glsl-optimizer/src/compiler/glsl/glcpp/pp_standalone_scaffolding.c":"d11aeb3acfe966d1b78f1ee49804093f2434214c41391d139ffcb67b69dc9862","glsl-optimizer/src/compiler/glsl/glcpp/pp_standalone_scaffolding.h":"abbf1f36ec5a92d035bfbb841b9452287d147616e56373cdbee1c0e55af46406","glsl-optimizer/src/compiler/glsl/glsl_lexer.cpp":"272b9fc1383d72b81bfc03fa11fdf82270ed91a294e523f9ce2b4554bd3effa9","glsl-optimizer/src/compiler/glsl/glsl_lexer.ll":"2b57d9f9eb830c3d7961d4533048a158ee6f458c8d05c65bea7b7cfbc36e4458","glsl-optimizer/src/compiler/glsl/glsl_optimizer.cpp":"195487f3d1dca5513712a8c2294f3d684a0e945e6f4e8b7142387f044a5dd7db","glsl-optimizer/src/compiler/glsl/glsl_optimizer.h":"22e843b4ec53ba5f6cd85ca5f7bad33922dca8061b19fb512d46f1caca8d4757","glsl-optimizer/src/compiler/glsl/glsl_parser.cpp":"2a34cbe4afcef6eb0a6a16ea4e920dbad67859cfeefaa1a779991280a5a63e0c","glsl-optimizer/src/compiler/glsl/glsl_parser.h":"a2b79346a0a5b7e75a383f007ac8e07ff85dc12b4ad296d7089e6a01833efec0","glsl-optimizer/src/compiler/glsl/glsl_parser.yy":"91d99418e293cd95dd3ca5c3407b675299904b60de90eb093be248177bdfab3b","glsl-optimizer/src/compiler/glsl/glsl_parser_extras.cpp":"4802ff2208f47849dd6395475e5645e53d696b8cb2ce58e16fb4f86bf9080cb4","glsl-optimizer/src/compiler/glsl/glsl_parser_extras.h":"da52f86890497b7532dd5626f29e1ab12f892ca4d0ade367136f961a9728ffc5","glsl-optimizer/src/compiler/glsl/glsl_symbol_table.cpp":"6660fb83c0ddddbbd64581d46ccfdb9c84bfaa99d13348c289e6442ab00df046","glsl-optimizer/src/compiler/glsl/glsl_symbol_table.h":"24682b8304e0ea3f6318ddb8c859686bd1faee23cd0511d1760977ae975d41bf","glsl-optimizer/src/compiler/glsl/hir_field_selection.cpp":"72a039b0fcab4161788def9e4bedac7ac06a20d8e13146529c6d246bd5202afd","glsl-optimizer/src/compiler/glsl/int64.glsl":"303dbe95dde44b91aee3e38b115b92028400d6a92f9268975d607471984e13eb","glsl-optimizer/src/compiler/glsl/ir.cpp":"0d744d7576e0462fe1db1b7efeff08e7c2b318320a41f47dec70c8e5c7575a25","glsl-optimizer/src/compiler/glsl/ir.h":"e58af2cd704682117173590924f3cec607c2431dcefe005f17d707b734477673","glsl-optimizer/src/compiler/glsl/ir_array_refcount.cpp":"1fde229ea3068d8ef7b9294d294e269931c6dbbcead9a6e7e7cbf36d4a629370","glsl-optimizer/src/compiler/glsl/ir_array_refcount.h":"9ba5f4094805aad4802e406b83bbf7267c14310d0d550b58272d91395349bf1a","glsl-optimizer/src/compiler/glsl/ir_basic_block.cpp":"1e2920b1c0ecb08424c745c558f84d0d7e44b74585cf2cc2265dc4dfede3fa2f","glsl-optimizer/src/compiler/glsl/ir_basic_block.h":"81be7da0fc0ee547cd13ec60c1fcd7d3ce3d70d7e5e988f01a3b43a827acdf05","glsl-optimizer/src/compiler/glsl/ir_builder.cpp":"daba29c5a1efdd5a9754f420eb3e2ebdf73485273497f40d4863dadeddb23c0d","glsl-optimizer/src/compiler/glsl/ir_builder.h":"2822e74dd3f6e3df8b300af27d5b11ea2dd99d0e5e7ca809b7bbcce9833c483c","glsl-optimizer/src/compiler/glsl/ir_builder_print_visitor.cpp":"8c6df5abf2fe313363f285f171c19ca6c8ee4f3bc2ed79d33c0c88cc8be45c48","glsl-optimizer/src/compiler/glsl/ir_builder_print_visitor.h":"799852adc3a0e54d04080655e7cebfa0d3bf5b6ffed5d8414f141380665d4db7","glsl-optimizer/src/compiler/glsl/ir_clone.cpp":"9c2622f3260a120526fb1fdbde70d69de842914e20c29e925373659a2b5c3eaf","glsl-optimizer/src/compiler/glsl/ir_constant_expression.cpp":"21f9d4e2d8e0f423489b18f871e8243472ec79de973ba02ad67b79ce681b492d","glsl-optimizer/src/compiler/glsl/ir_equals.cpp":"bca28533a6310b0fc152b56d80872368f1510dc62ed6e8ac199b9ffa7fac02e7","glsl-optimizer/src/compiler/glsl/ir_expression_flattening.cpp":"7e918d4e1f237eca01396004015865ce345afe32a876c9dbc6728576a1a7eae4","glsl-optimizer/src/compiler/glsl/ir_expression_flattening.h":"f45b66aa9497520e7e08e612d24b308477c34477fbd963ee9320eac664957f16","glsl-optimizer/src/compiler/glsl/ir_expression_operation.h":"d8a94147da73b169a99c95378eecc0570983e1805ad201a773ff1a42d5d50a24","glsl-optimizer/src/compiler/glsl/ir_expression_operation.py":"38bafed32b98ff492cc611514160a39c2e6e17d198b5d290b5727bcd4b55aee1","glsl-optimizer/src/compiler/glsl/ir_expression_operation_constant.h":"8c751e72df480d5c012ebe0ebe25209464b1af32c23e199e4552169c425c7678","glsl-optimizer/src/compiler/glsl/ir_expression_operation_strings.h":"fc9251dcab8e73e00ffc983da3ead3cf32c160eaec1111e23b45eff6f9f4f37e","glsl-optimizer/src/compiler/glsl/ir_function.cpp":"7537365fc0fbe4b37a26b9a2146cc64d3e9a774d60eab63b65002ad165ae8fc7","glsl-optimizer/src/compiler/glsl/ir_function_can_inline.cpp":"faddbf112187a048d502716a3fb82570a322299ba2a3abd79388382c82040bfc","glsl-optimizer/src/compiler/glsl/ir_function_detect_recursion.cpp":"9176973eaf5c0a984701f953bb7a80f37dca43d59b5bce50fc69b3f02f2902d7","glsl-optimizer/src/compiler/glsl/ir_function_inlining.h":"9739493f99c489987d650762fccdd3fb3d432f6481d67f6c799176685bd59632","glsl-optimizer/src/compiler/glsl/ir_hierarchical_visitor.cpp":"c0adaa39f0a94e2c2e7cee2f181043c1fd5d35849fef1a806c62967586a4c3ca","glsl-optimizer/src/compiler/glsl/ir_hierarchical_visitor.h":"0bfe80bbbf9b0f4ae000a333df77fb1cd144a8cda11c29b54c1eabf96f2c351d","glsl-optimizer/src/compiler/glsl/ir_hv_accept.cpp":"caf7ce2cd9494aadd3c58bcf77f29de58368dc9e347a362bbf37f8bda9509b80","glsl-optimizer/src/compiler/glsl/ir_optimization.h":"cd394c803199d96e23a1c9e3f5d2758a5d6645a56c7ec8bd7fe0a6bbe0808351","glsl-optimizer/src/compiler/glsl/ir_print_glsl_visitor.cpp":"1ee46cca6c3562c018614412181c02faf494c92c07d2c7b345d19b355e9b52f3","glsl-optimizer/src/compiler/glsl/ir_print_glsl_visitor.h":"1ad1bd3efd1ace39051c13f904c05fd80425d329444f9a8d47fd6d948faf46e0","glsl-optimizer/src/compiler/glsl/ir_print_visitor.cpp":"066c65b8e181d962ee913388b69c7941362685b66ffe1758abd31b384a96934a","glsl-optimizer/src/compiler/glsl/ir_print_visitor.h":"4573eb93268a2654c14b505253dd651e2695d43dc745904d824da18305269b95","glsl-optimizer/src/compiler/glsl/ir_reader.cpp":"06bfba802c8354e5a8b2334b6d78d6297de18235bedd3f8fbb382c89870b02f2","glsl-optimizer/src/compiler/glsl/ir_reader.h":"63e3f7f1597936a7011d5b520e171b197bf82bee6c1560d822c3edf5aaa6f9e9","glsl-optimizer/src/compiler/glsl/ir_rvalue_visitor.cpp":"84b5c5d746555adca85759c2912fe48010232b7c1c0bd2cf03bd04067a85e66f","glsl-optimizer/src/compiler/glsl/ir_rvalue_visitor.h":"fd8c561b71085d3211fff85ed514fecb299d8ce19a04bc063419a55b6d840525","glsl-optimizer/src/compiler/glsl/ir_set_program_inouts.cpp":"ab9f115ce9e7f312d9c7978340ced0dc4ae6d13a80e08442ba9709d11d50cae5","glsl-optimizer/src/compiler/glsl/ir_uniform.h":"683ae6896b1a08470c090be5f822fc31cd434eab9216e954b9bba24a46975109","glsl-optimizer/src/compiler/glsl/ir_unused_structs.cpp":"15d27cd5ef2748922b8341d7887e6c5bc6d1f4801c36d25c769e48d364342398","glsl-optimizer/src/compiler/glsl/ir_unused_structs.h":"13387b49c23093575276b25b9dfd31fedd8f131c5c4f3128ab04cf03e15b5295","glsl-optimizer/src/compiler/glsl/ir_validate.cpp":"bded6922c63173e7cb15882bd7fd0e25b9a478c4223fc0ffcfd0890d137f4ed1","glsl-optimizer/src/compiler/glsl/ir_variable_refcount.cpp":"2764a3cad937d53f36db7447c3a5b98b04bf153acf81074d971857fc5bca460d","glsl-optimizer/src/compiler/glsl/ir_variable_refcount.h":"b0668e3eb1501ef65e38fe12830742ecb3d28e6039f30e366c8924efc29b4a39","glsl-optimizer/src/compiler/glsl/ir_visitor.h":"f21b3534c3d66d5fb707d1581fece7e1eb043523afbaedf89918cfb031c6df94","glsl-optimizer/src/compiler/glsl/link_atomics.cpp":"360f0209e11f367ba358223597b0a118bae095bff16337cf03f1fb89c5b80ca6","glsl-optimizer/src/compiler/glsl/link_functions.cpp":"de7895da8aa33a1e3c2c1eb2fdaf267ab5d1fbfdb79ae2e67f95211e946e294c","glsl-optimizer/src/compiler/glsl/link_interface_blocks.cpp":"1926cfa73810704eb19b916c1b2cdb9321155e2f98b2a0a57c7c3c6e960540cd","glsl-optimizer/src/compiler/glsl/link_uniform_block_active_visitor.cpp":"1e14e06ca3b2c1089cfba2e8eaf0c1f373d9d6374b6082f320962dd71ae09611","glsl-optimizer/src/compiler/glsl/link_uniform_block_active_visitor.h":"fd58c155af645295bb6aec08797889de586f4d919731de2bce57e8dce59bb048","glsl-optimizer/src/compiler/glsl/link_uniform_blocks.cpp":"09589f49776dce32e6c4044937de7e0c839a9754ad31960148f8f9e010658997","glsl-optimizer/src/compiler/glsl/link_uniform_initializers.cpp":"bf98e08c12db466acf9623cbeb8fa8e3b4002512722e7a6521287f558a099f37","glsl-optimizer/src/compiler/glsl/link_uniforms.cpp":"84bad5b1377362cecf259b05124239be5220b03ce1c0c61b59bd9a47e4379af2","glsl-optimizer/src/compiler/glsl/link_varyings.cpp":"09e6a9395f142d6029e8d58cd993685f2bed35125d193a39bc7c96ec6ebed6f8","glsl-optimizer/src/compiler/glsl/link_varyings.h":"44a1270f8ed61cab8481358c7342943958618bb5057cd342369373b79c74abd0","glsl-optimizer/src/compiler/glsl/linker.cpp":"dcfbfab55f31c81afc90aec7d0a1620a80a4a9eea642efb20a99eaafc32ba95b","glsl-optimizer/src/compiler/glsl/linker.h":"ecf94b4ad75ef461c27c557fda4bd25f34c91930822b8e1d729ec84520d4a049","glsl-optimizer/src/compiler/glsl/linker_util.cpp":"6bef0fd8438c4de02140e93e1af6855e56f7aed6f9dbcb820e54bbaa4ae0eb6c","glsl-optimizer/src/compiler/glsl/linker_util.h":"462a266538ba9812f96ac9226519ba3b2e54ff794adee60c143e8676c5c047d8","glsl-optimizer/src/compiler/glsl/list.h":"8fffadc41788723420e6b4c1c19b6e400682fe72d458f4a0aedcb600b9404dfb","glsl-optimizer/src/compiler/glsl/loop_analysis.cpp":"57ecd573477c68091c7cc99537faa7139a8f395935e3d4f10144cefdefb5a611","glsl-optimizer/src/compiler/glsl/loop_analysis.h":"a85f045a038ee5b5176063e85d7988865862c44ab0580f771b993a042d0b69cc","glsl-optimizer/src/compiler/glsl/loop_unroll.cpp":"bd4292ea2809f5a669bcb76ceaa1ac365772dcd638c579c3ed10275214901a54","glsl-optimizer/src/compiler/glsl/lower_blend_equation_advanced.cpp":"8cfbef140d9c4b4d2f57bfa05c9c374d31a121d0f87afce94333f049023b654a","glsl-optimizer/src/compiler/glsl/lower_buffer_access.cpp":"1ae221c3c7a95aeb867207e7a742be635f91b406c157747bfd6ddf10274d97fb","glsl-optimizer/src/compiler/glsl/lower_buffer_access.h":"807886953a576a323591798cbca5e2df24295ea893b28affd8ffb5926cebaa04","glsl-optimizer/src/compiler/glsl/lower_const_arrays_to_uniforms.cpp":"608403f0eeeedf21cfcd3014116e0f44e28cbdf6c4c32aac7e613e64e30205e1","glsl-optimizer/src/compiler/glsl/lower_cs_derived.cpp":"179905cd47a294122adeb5b0abfed6f2f67782dcde21b544d1ee2c1985154e66","glsl-optimizer/src/compiler/glsl/lower_discard.cpp":"3b361b2db0004d544d64611cb50d5a6e364cf6c5f2e60c449085d7d753dd7fb0","glsl-optimizer/src/compiler/glsl/lower_discard_flow.cpp":"f5c29b6a27690bb5c91f196d1a1cf9f6be4f1025292311fe2dac561ce6774dee","glsl-optimizer/src/compiler/glsl/lower_distance.cpp":"a118c85493d5d22b2c059a930c51a5854896d4b1dade76598eaa985e5a3dff8c","glsl-optimizer/src/compiler/glsl/lower_if_to_cond_assign.cpp":"469e617757fd1728709cce021aac5c8da05ee503bf5366977bdc4ef7a6d83950","glsl-optimizer/src/compiler/glsl/lower_instructions.cpp":"39dc7589b56758884cb322287d8bb8cd81d3bd8986fadc9fd4d68bf422b1f281","glsl-optimizer/src/compiler/glsl/lower_int64.cpp":"d1ed41196880dd53c7b13e2782f9423f8442bf1d46186e8be92b1b66218a83ee","glsl-optimizer/src/compiler/glsl/lower_jumps.cpp":"f638ef8eaec462bc2ce4b1874f59c66aeed24774dfdd7e9fe2b5eab7206e4524","glsl-optimizer/src/compiler/glsl/lower_mat_op_to_vec.cpp":"33d55d38cbe4af8e345765214303d5ace282e024992e7a9420f4338b9a4d1e34","glsl-optimizer/src/compiler/glsl/lower_named_interface_blocks.cpp":"16063ac127bff75a68272070ab11c21c25101edbff62b4c68f4983b4cd941af0","glsl-optimizer/src/compiler/glsl/lower_noise.cpp":"cfdf639cdf5a1f76a7a73234e1bf0c72e5d2089cac44a6663c2012b7f99431af","glsl-optimizer/src/compiler/glsl/lower_offset_array.cpp":"3b00773399135aea85746a5a68b96ef000bc6841be1a2c8e6f25c516628b0949","glsl-optimizer/src/compiler/glsl/lower_output_reads.cpp":"a0fc9975d5aa1617e21fc6c353659a9802da9e83779a3eef4ec584f74b4dadc5","glsl-optimizer/src/compiler/glsl/lower_packed_varyings.cpp":"2cfecd9e8e12603ce8038db74c9dac0dcb7fb77f6ec34baf76896dc235e214bd","glsl-optimizer/src/compiler/glsl/lower_packing_builtins.cpp":"79a13d161fe505a410ab948d92769395708693ec888153630fa240e5b97e356f","glsl-optimizer/src/compiler/glsl/lower_shared_reference.cpp":"ea2dccf50a83bc19391bf6b7ab6aa53c0005f427af4066d25140340af9a4beef","glsl-optimizer/src/compiler/glsl/lower_subroutine.cpp":"f69fa53650eeb6f2944fce4d36a6e0a423e6705f3a3bd3389c7fadb83cfc8802","glsl-optimizer/src/compiler/glsl/lower_tess_level.cpp":"b196c9d424c0569f3e85d75c2d125af21566cb113d69036db87c0990703e0fa7","glsl-optimizer/src/compiler/glsl/lower_texture_projection.cpp":"4d247f244272adc8250fd888d8d932a140dd5de4d1efc7a58492c3c2b8291527","glsl-optimizer/src/compiler/glsl/lower_ubo_reference.cpp":"89bdbc6c1669230c644c0857db1ce2781ec61d349ecd08c7914146e1f4750a4a","glsl-optimizer/src/compiler/glsl/lower_variable_index_to_cond_assign.cpp":"fce930f29ac9405b297d1f749d68f59506b89c70b4ee1b1ab8cf49a34cc71ecf","glsl-optimizer/src/compiler/glsl/lower_vec_index_to_cond_assign.cpp":"3c67d851a11a55fad1c49a550f3a0cfe50892d33a3f238ce266cd829eba510a8","glsl-optimizer/src/compiler/glsl/lower_vec_index_to_swizzle.cpp":"f5ec666b73e1415cbab32519a53605ed385f3b03e889560373dbce69dda5000e","glsl-optimizer/src/compiler/glsl/lower_vector.cpp":"f7c13f5572ebe09b6a71553133b2cf003cd4b77b9657600672ee3b21bf890725","glsl-optimizer/src/compiler/glsl/lower_vector_derefs.cpp":"b05793da6dd620a531b43df5af8b2ecbc37b9db0c88910f5724ea10bcd057e19","glsl-optimizer/src/compiler/glsl/lower_vector_insert.cpp":"fee772ec17eea5e86a529bf9c5fa2ee0d29a5982bb75ebc6d68ed36cd19aa299","glsl-optimizer/src/compiler/glsl/lower_vertex_id.cpp":"690e8715182e03fead5cc5a35251fb4f41b357e4c71a1dfbc4bd7be19862b56d","glsl-optimizer/src/compiler/glsl/main.cpp":"d9d3841884a388a57e0adcd6b830ea59fb3fb7c5d78f2c0796f11d4ce3c9f96a","glsl-optimizer/src/compiler/glsl/opt_add_neg_to_sub.h":"f5054944bfd068810629080d0ea11df78b3f57a8f86df75e13ca50157ad1964d","glsl-optimizer/src/compiler/glsl/opt_algebraic.cpp":"121d58ee9dd11e3fffca31d8a1a3f3abcf80aed174a2c740986bbd81cdeb0e6d","glsl-optimizer/src/compiler/glsl/opt_array_splitting.cpp":"19d3ce0e815438f4df9ab2890e767b03a4f3f191b53bb30c0217cf2ae6a95430","glsl-optimizer/src/compiler/glsl/opt_conditional_discard.cpp":"0e44e0e126711a3725c1f3a2aa65ff03c381fed08680ffc30101aae60f716c4e","glsl-optimizer/src/compiler/glsl/opt_constant_folding.cpp":"a088d04d9b45f9e55e235835648f614c89b7803c03a6d4f6a6d1a6bc1f0228bd","glsl-optimizer/src/compiler/glsl/opt_constant_propagation.cpp":"710109a6249858e7cf764dbbf695836e0fe421f8a651e067fb989974e7b474ff","glsl-optimizer/src/compiler/glsl/opt_constant_variable.cpp":"4a395474e9a8aa45b84b6b683c7783791400a30e75a6814d3fbb722d85c12aa2","glsl-optimizer/src/compiler/glsl/opt_copy_propagation_elements.cpp":"ffa0f50863995e0d2e31f55a52e82319edc71e520987bebd7f7e561ea331c64b","glsl-optimizer/src/compiler/glsl/opt_dead_builtin_variables.cpp":"84e8747b948232f01dd56b428b9315f96f9511f605f240119fc446fae28981a9","glsl-optimizer/src/compiler/glsl/opt_dead_builtin_varyings.cpp":"761523e88f5b3ba785170f4d7205e94fa99acb7e74d29efbe40e1c010e1dbdb3","glsl-optimizer/src/compiler/glsl/opt_dead_code.cpp":"fd1ba2da7337d4e5dad17f5c2d73d9cc8880305f423e85d64cf94553588fa401","glsl-optimizer/src/compiler/glsl/opt_dead_code_local.cpp":"bfc0b6d5a42d80c9c6b57130d3322b6940b4a02021488f4aeef489b2c3652a7a","glsl-optimizer/src/compiler/glsl/opt_dead_functions.cpp":"774cae6536d02edf26e996a2a895e1f62d5098f16dc96b44798b4fc731a9a95f","glsl-optimizer/src/compiler/glsl/opt_flatten_nested_if_blocks.cpp":"3696a5c55f02e20056e085bc2714f73ac992f221b6f3387d655068e86b512046","glsl-optimizer/src/compiler/glsl/opt_flip_matrices.cpp":"44f0fe05b49329667671f88c96dc86ab3fe1459ff7b87f2b2d88de2d49829f9f","glsl-optimizer/src/compiler/glsl/opt_function_inlining.cpp":"fb56a33c90419a01676b57cbd91d0674a54cca40e6defaacc88dd33facebc131","glsl-optimizer/src/compiler/glsl/opt_if_simplification.cpp":"ac406eb35e379c357641d6c5749f50c65961455924d3dc884e2b90046fa92c5c","glsl-optimizer/src/compiler/glsl/opt_minmax.cpp":"27c6c5357043b5c6e5d594d7476e9a00e8f6db033a86f5c984243f44ed492430","glsl-optimizer/src/compiler/glsl/opt_rebalance_tree.cpp":"8bb6329dc0f299042368fc81934c2df019b45ab9f7aa0415d4e57b8d1ff98c9f","glsl-optimizer/src/compiler/glsl/opt_redundant_jumps.cpp":"222c73e2ac7a938ebb6428cc6c780c908ff6156d8ff935b04fed93a48fc10496","glsl-optimizer/src/compiler/glsl/opt_structure_splitting.cpp":"2edc79cc13f3177934e0443ad62f5976a1991f01f86ea303a803434849b13a47","glsl-optimizer/src/compiler/glsl/opt_swizzle.cpp":"015d0abddfe507f67c4b96c82988d861d018ededf7bf055e2bcbe9ea92da694e","glsl-optimizer/src/compiler/glsl/opt_tree_grafting.cpp":"46d28ac983ea244a4315bdc0e8892979ec4d1f9b9a96ac8a8a08006d9bc5e878","glsl-optimizer/src/compiler/glsl/opt_vectorize.cpp":"d80ee43bb97d9f016fb9c5e1e06f5b2afa569811f368ba067be794ec11d085fb","glsl-optimizer/src/compiler/glsl/program.h":"2982447e2abd35371e273ad87951722782a8b21c08294f67c39d987da1e1c55f","glsl-optimizer/src/compiler/glsl/propagate_invariance.cpp":"080943e21baa32494723a2eefb185915d2daae1f46d6df420145c5ad6857e119","glsl-optimizer/src/compiler/glsl/s_expression.cpp":"1ced972bc6ecc8eab4116ea71fb0212ab9ae5bcc0be3b47aa5d9d903566b3af1","glsl-optimizer/src/compiler/glsl/s_expression.h":"65b847e30e22a809b57d0bc70243049c99d9c6318803c5b8d0826aba55dc217e","glsl-optimizer/src/compiler/glsl/serialize.cpp":"d57addf5e72954a98192a09287f5013a86a802b763112ab88b6595a356384864","glsl-optimizer/src/compiler/glsl/serialize.h":"57425732eba1233d928e5f07f88b623ce65af46b3bb034bf147f0a4b7f94f9a1","glsl-optimizer/src/compiler/glsl/shader_cache.cpp":"e0c5c433f2df3fccdf1d61281bfcb0ee5633433339b97c697d64db99611cbaaf","glsl-optimizer/src/compiler/glsl/shader_cache.h":"9217164d8d7f54aca0fe5922c7187095a6ae0cb703b196b79805aeef07a7e697","glsl-optimizer/src/compiler/glsl/standalone.cpp":"37e5566b2a20ab8a9f2262735a37598482816abec3e348221d8d95c5a2762aa1","glsl-optimizer/src/compiler/glsl/standalone.h":"788d6a39b6b93a7ed6eafa2c8f9c439ac84aeddb7545f3d4381af29bd93aaa2e","glsl-optimizer/src/compiler/glsl/standalone_scaffolding.cpp":"f71ba2958c75f1504ea6ef56d6ccdc3c0ea291cac38513978fa0b8bee1595e96","glsl-optimizer/src/compiler/glsl/standalone_scaffolding.h":"d921a617ea82b9e49413314492a645c44356de503581b1be3f1b57de236e480d","glsl-optimizer/src/compiler/glsl/string_to_uint_map.cpp":"d824bf5b839bd39498dc9e457103cdbe3e5289ddf7564107c27b1505948dd31f","glsl-optimizer/src/compiler/glsl/string_to_uint_map.h":"e2f18e66359c9d620e085de7f4a334a47df9c66e65a5bfe8b734c627bec04104","glsl-optimizer/src/compiler/glsl/test_optpass.h":"b27b8f35f5387e7ce4982bb51c7b63ccf14f91757f3108a5d02ed006925bb8a0","glsl-optimizer/src/compiler/glsl/xxd.py":"376484142f27f45090ea8203ae2621abf73f06175cb0ee8d96f44a3b9327f4bd","glsl-optimizer/src/compiler/glsl_types.cpp":"61664f65ecf47c9787f71020050bcef67215afe2885b9b4656bbd2f9b2b575b5","glsl-optimizer/src/compiler/glsl_types.h":"3c9f573559192c1c339af967cd65224be54c9e05cc4758b2ffac9b0b7485c88f","glsl-optimizer/src/compiler/shader_enums.c":"f97a3b1b07ef70b387e540b538af8073fe5f7ffb591515e3abf913acdd7f34bc","glsl-optimizer/src/compiler/shader_enums.h":"9681494cb850bd4ccd1fd18471af00456d68122dcc40a916fb061c6d6ed4854a","glsl-optimizer/src/compiler/shader_info.h":"457bdf6409ab07a154ef172c65380d4973e7cb11d14d36a6d7b3b7c66e2edd2f","glsl-optimizer/src/gallium/auxiliary/util/u_half.h":"a4e2ddd24cf9a1e04f18765dbc29d5acf1a3f71da77a91b034fd0e3a7d047268","glsl-optimizer/src/gallium/include/pipe/p_compiler.h":"587317125c88baa3a562fa9a1985f905a2f47922af29d23b86b78117d08790b4","glsl-optimizer/src/gallium/include/pipe/p_config.h":"a27692fc35f9e55df3224b7529e66b3001e911e94e6bc5f8f569e493e1ee3fb7","glsl-optimizer/src/gallium/include/pipe/p_format.h":"d15e7fbe83174e0e0122e25a1720dda487cbe5776b764ce71055512922088f10","glsl-optimizer/src/mapi/glapi/glapi.h":"73632a625c0ddabc401205e8b5a81eb8af8506868efe4b170d7979ec3619e9c5","glsl-optimizer/src/mesa/main/compiler.h":"79e3bf40a5bab704e6c949f23a1352759607bb57d80e5d8df2ef159755f10b68","glsl-optimizer/src/mesa/main/config.h":"5800259373099e5405de2eb52619f9de242552a479902a3a642a333c8cb3c1e7","glsl-optimizer/src/mesa/main/context.c":"02c18b693312dc50129d66e353220df736cba58a0faaa38316d861025441e78a","glsl-optimizer/src/mesa/main/context.h":"407bddf4a338a0a65f9317e3d076910502d43c948c8a6b7e700e55212fdc155b","glsl-optimizer/src/mesa/main/dd.h":"845ead03db94fab79c7b8e3155bb9c795d1a91b10857a745afc666046e077e4f","glsl-optimizer/src/mesa/main/debug_output.h":"7312422e90b8c0e34028ac27280e438139b5cba525c99deb3ac883cd3d87e452","glsl-optimizer/src/mesa/main/draw.h":"3f5fea0fe2fc5e6fa8db4f4db2481a5d2c683a500ac290d946b063ddf579fd74","glsl-optimizer/src/mesa/main/enums.h":"87d562a6764f51c014a2274fa7c3aca17c04441537ddd56b2554f13c6fffea92","glsl-optimizer/src/mesa/main/errors.h":"c79444b5df289c90fbb22a33b2d0c23917d9fc4510960088f0b79e53bb56b1b2","glsl-optimizer/src/mesa/main/extensions.h":"483fe6654938ce1c8e8ded5dde2eefd2710fcf4dade37fb9c8d08c128f362113","glsl-optimizer/src/mesa/main/extensions_table.c":"17642d1a8c9a0bf2bd61060052d33ff14a005d2b962e6cf91465797a50851e85","glsl-optimizer/src/mesa/main/extensions_table.h":"d78d97a1df035a9d7562cec0cc6feadf79888b2eebc79336f3eb3e73321ee2ce","glsl-optimizer/src/mesa/main/formats.h":"a45bb586e2f990b906e605b7233c51389e72dfa7cd33fb220f21d78c4edcd18e","glsl-optimizer/src/mesa/main/glheader.h":"58217b33eead6aa6b23cd4a291cefeaa6cb84e465f4960daffca97c44d6d1c35","glsl-optimizer/src/mesa/main/hash.h":"5ea00760025c688cf81ba25cb99ebcfcd2c79091d44fc5b6257b4876d11ea04e","glsl-optimizer/src/mesa/main/imports.c":"c102235731498dfb7204f753c9e650daaf9e4609ba5d85aafdaca994c7b88325","glsl-optimizer/src/mesa/main/imports.h":"31634703de1e30bc3e40d63dac4055ae025a608ceaf3c9da5d64c8c5e9a31fb2","glsl-optimizer/src/mesa/main/macros.h":"fc04dd953826c9ff1b2850fbeaa2a6c59c964450b4923f52e3425e7c4f58b085","glsl-optimizer/src/mesa/main/menums.h":"5dfac0e2279d60b0cd0c7b9fc2a5021620d0f6282ed2e738c420214e3af152d3","glsl-optimizer/src/mesa/main/mtypes.h":"69eebf3ed20da8042fce544f92ad81454234d5968e6f9a9c4db38184fefbad3f","glsl-optimizer/src/mesa/main/shaderobj.h":"9f0dfe96d0c2154201adef942bd36053533ac7b2492fb3786acda5bea514c75e","glsl-optimizer/src/mesa/main/uniforms.h":"4e331e6ad6e9cbded978b4082dbe0a57c1f8f01327446bb6892bfc179976c38b","glsl-optimizer/src/mesa/main/version.h":"9d0a13a758099302dc55cf7d045791834a89b0f9d4cf17b2692259b369a8a9a1","glsl-optimizer/src/mesa/math/m_matrix.h":"a37b19f182e070db3df93b0ede43c22fb8be8c2906504133ee6dbd7db1185d8b","glsl-optimizer/src/mesa/program/dummy_errors.c":"1820e305515b4c5e041f5e1623266a48ec8f076a155310be7d60637101f593e4","glsl-optimizer/src/mesa/program/ir_to_mesa.h":"b47f58d22e3ca2ae42d52501ea769d15c4476834944fa97eeccd3a3439211d00","glsl-optimizer/src/mesa/program/prog_instruction.h":"ab3832152a7e144b59e5a2264b2c29db56d93be31e76bbd958527a56771b40eb","glsl-optimizer/src/mesa/program/prog_parameter.h":"2211768d6458b21f84c3a58083a92efe52a9902ece92a23ee83184c3a3a2e16a","glsl-optimizer/src/mesa/program/prog_statevars.h":"fc413698f84bc52d45fdeae0471934ee9904bfb7eac1a2b5f70446e54bcbbdca","glsl-optimizer/src/mesa/program/program.h":"f61c9d123f28c7ff8b390648d35f329e7b6e68e33823239d539b7be8384541bb","glsl-optimizer/src/mesa/program/symbol_table.c":"f275a98f1afc91399a14dbbc5a9d222bdf6e21764c7b83ec688962b40caece91","glsl-optimizer/src/mesa/program/symbol_table.h":"631dc35ac48d5e87962d45507461920f6575610960ffcc42a08cefeb43300cda","glsl-optimizer/src/mesa/vbo/vbo.h":"b9bf5ad54267cfd7af2e842dda029090dcc7db1c5b7825914736c3c132909d95","glsl-optimizer/src/util/bitscan.h":"d4fcb47b57a50d70cb97f99ca3e619bc06282a877768a435e009775ce8d77f36","glsl-optimizer/src/util/bitset.h":"c40f78515c6230fed18345c6751ce33833a49da7a27901c7e6d7340cbdcbc5e7","glsl-optimizer/src/util/blob.c":"214fea1499bc25eed6eb560651f3358cadbaf507b4ec8bdb8f894c13010ab3f5","glsl-optimizer/src/util/blob.h":"093d5dc1acbd424eaaf8e48d6735d4c4acf8d5d48d7226fa21c249e32f0108aa","glsl-optimizer/src/util/crc32.c":"2f3467a046b3a76784ecb9aa55d527698c8607fd0b12c622f6691aaa77b58505","glsl-optimizer/src/util/crc32.h":"59bd81865e51042b73a86f8fb117c312418df095fed2d828c5c1d1c8b6fc6cd4","glsl-optimizer/src/util/debug.c":"4e307954f49d9700a99510684f930a8e404c8e1078f5a774f9245711e963fe9a","glsl-optimizer/src/util/debug.h":"50068d745c4199ccbd33d68dd4c8a36d2b5179c7869a21e75906ddd0718ca456","glsl-optimizer/src/util/detect_os.h":"343a8790d17a3710c6dd015ee367f84e3902ff3f2e36faca2bf93f9d725d3574","glsl-optimizer/src/util/disk_cache.c":"c963a961597ce5c1de98424f38b3a4163c8479410539bbe1bc142c06b2b5e1d1","glsl-optimizer/src/util/disk_cache.h":"e83314fb14134a8e079b15e470a6376ba5a8253701f048c890a62b7e55d64bc8","glsl-optimizer/src/util/fast_urem_by_const.h":"e108fce804616c47d071dfe4a04163eec1126e448ed1aa89abb6b3a6d772bd5b","glsl-optimizer/src/util/fnv1a.h":"ab2596f19c6adf431ae27618f62c5743e24ad23ef83bb359a4c4c218245ab459","glsl-optimizer/src/util/futex.h":"fae18b3385e7bd683e06c399aae64428c92133bb808e5c04d957dfea0c466910","glsl-optimizer/src/util/half_float.c":"11bc2584493d5d9d46e8c8a619a0307cf150bf5ab5d0f96bb764b061dc37a00e","glsl-optimizer/src/util/half_float.h":"698a6d628c38244ef816cf69dda6e3cc7341725956e990bddde11a11e2565330","glsl-optimizer/src/util/hash_table.c":"f8b81f85ae418f9ee5b077bdbfafde708325357bcbb75cb04924316d629c7a8f","glsl-optimizer/src/util/hash_table.h":"217191bb360592e2232f187473c10287d2cda8ae6fa5c53d0ef74c8c206118b4","glsl-optimizer/src/util/list.h":"9fab03c6a78186bb5f173269f825f6ce976b409d931852e3d93bac632e07989a","glsl-optimizer/src/util/macros.h":"5057bb77c9ffec4ccdb4fb4640dd6eb05caf549e8665ea4afb5ba1142a4a5a17","glsl-optimizer/src/util/mesa-sha1.c":"00c692ec353ebc02c06c57c5a71de0ab7a119f86a4146f452e65ec87e4944417","glsl-optimizer/src/util/mesa-sha1.h":"bff4c29f4bf7cdbcefb30fa0c996a7604a380eba8976467c2a60e7cd328f7e26","glsl-optimizer/src/util/mesa-sha1_test.c":"25da89a59d51469f77b4c468ca23ffdce0a7a1166a70b6cc23026a6800b0143c","glsl-optimizer/src/util/ralloc.c":"691183679ceb2f1e0fbfe0669f5accd239ceb3449df7586c7269b011765fdc35","glsl-optimizer/src/util/ralloc.h":"e573c45875ff1530f0dbee9a93ae55535fdac8d5cc88a79ebc327c688824bde5","glsl-optimizer/src/util/rounding.h":"bee6e21354e569c58f0b34a34351903394f6ad890391dd9c8025a399891912e1","glsl-optimizer/src/util/set.c":"a71293beff2fc7da6ca4118f89e8758d024571049207db3d2491084cafa8a3a5","glsl-optimizer/src/util/set.h":"3e39ca161e7ed4ec7c436cc9c7919ed9a55ed1b71edbf2caf6f9bcfd9bc578ed","glsl-optimizer/src/util/sha1/README":"00af7419af05247081858acb2902efd99fcda2ce16e331079f701645bb3729c0","glsl-optimizer/src/util/sha1/sha1.c":"1403bbe0aad42ba3e6be7e09f7cad87a6a8c4ad5b63962f7b92b9f37d8133b04","glsl-optimizer/src/util/sha1/sha1.h":"68d9f240eab2918026ecdf22be36811abbd4f1389f6c36e31258041aeaedd247","glsl-optimizer/src/util/simple_mtx.h":"46dcc6a53a682cacd1e093950d37b2f2715865bc88c030ae8120ec76907578e2","glsl-optimizer/src/util/softfloat.c":"a97e51a96fe5e6a052c02aa6bbec683fe73fb88a8c087d9c930503e2120d8a2e","glsl-optimizer/src/util/softfloat.h":"66664b0250e83bf5dd4cc743acd119d076efcea624a0eab3d6b60718e6ee8811","glsl-optimizer/src/util/string_buffer.c":"63a1d1b1e34926c88ea00159cafbcd56568b805c4f64d1e8c97169fe313921fc","glsl-optimizer/src/util/string_buffer.h":"7b88d1b1d9c6cfb8e93331813535c127289437c75f822029e9a3bca8ea6b52ee","glsl-optimizer/src/util/strndup.h":"0273c4fdb7482cd7746881a63d3998648c6d63415ba85af1d1860f0e0dc504c6","glsl-optimizer/src/util/strtod.c":"5cf610d8a37373cf37cfb7aae903525d943b2674b1f32594c70b0eb19a8c9697","glsl-optimizer/src/util/strtod.h":"237396def4e264d35ed4bedea00ef9a4ceab6d7a11a18c770d9747d22c69ed2d","glsl-optimizer/src/util/u_atomic.h":"c02e809526c6c09ba8fe51f50b2490d1b6c8e5c7f3c4031ae958250d098fc3bb","glsl-optimizer/src/util/u_dynarray.h":"853d0fa6ff2261614488be624deb8a2b01e57c2c8eabc28578cbeed4ccc95694","glsl-optimizer/src/util/u_endian.h":"3ccea7e529740318d8a4b05c00db3adc9d1e292a52bdc56a05c9fae99209720f","glsl-optimizer/src/util/u_math.c":"c868a8c0886dc78f1b06b13404ba8b253090449045774dd56893ac9d75795184","glsl-optimizer/src/util/u_math.h":"57e7411c1afc06c43c1f087dc8de9ffe99ee0a67d28d40d8a87489aecffa9a0e","glsl-optimizer/src/util/u_string.h":"8bbc5f0d81cd482bf0aa201e95eb1c6ab3d6dfcb47c1c440e0c2fe5730cee14d","glsl-optimizer/src/util/xxhash.h":"2f2aff2fc6c0c929f52cf6ae7314122124c5be026d41ad1c357608383c4a37ad","src/bindings.rs":"79993db2058bde39f99ef483d02560d33b1cb882f6a552319e8b86eb6f9021e1","src/lib.rs":"04be1554cd829eb40864b06d80b491dd48117a4e3a601c7d482117f7a0391e67","wrapper.hpp":"f3ea34cc496f7d90b9bfcada3250b37b314c3524dac693b2ece9517bc7d274ac"},"package":"f22b383fcf6f85c4a268af39a0758ec40970e5f9f8fe9809e4415d48409b8379"}
+\ No newline at end of file
++{"files":{"Cargo.toml":"ca1e2ac475b5a6365f6c75ce25420cf6c770d376399b27adbeccf3c73cbdc12e","build.rs":"0686da18615ab58f9569489c9c9f48cc634f2eea2a0c38782c711493a240bc24","glsl-optimizer/CMakeLists.txt":"c7c98d4bd7d0996152883f5f71f1eb19cf3df5e2dd62069bddef430e5d5aa7f3","glsl-optimizer/README.md":"b18eef11a92d267d88a937b1154f7670ee433c730b102fdf7e2da0b02722b146","glsl-optimizer/contrib/glslopt/Main.cpp":"14ba213210c62e234b8d9b0052105fed28eedd83d535ebe85acc10bda7322dd4","glsl-optimizer/contrib/glslopt/Readme":"65d2a6f1aa1dc61e903e090cdade027abad33e02e7c9c81e07dc80508acadec4","glsl-optimizer/generateParsers.sh":"878a97db5d3b69eb3b4c3a95780763b373cfcc0c02e0b28894f162dbbd1b8848","glsl-optimizer/include/GL/gl.h":"1989b51365b6d7d0c48ff6e8b181ef75e2cdf71bfb1626b1cc4362e2f54854a3","glsl-optimizer/include/GL/glext.h":"2ac3681045a35a2194a81a960cad395c04bef1c8a20ef46b799fb24af3ec5f70","glsl-optimizer/include/KHR/khrplatform.h":"1448141a0c054d7f46edfb63f4fe6c203acf9591974049481c32442fb03fd6ed","glsl-optimizer/include/c11/threads.h":"56e9e592b28df19f0db432125223cb3eb5c0c1f960c22db96a15692e14776337","glsl-optimizer/include/c11/threads_posix.h":"f8ad2b69fa472e332b50572c1b2dcc1c8a0fa783a1199aad245398d3df421b4b","glsl-optimizer/include/c11/threads_win32.h":"95bf19d7fc14d328a016889afd583e4c49c050a93bcfb114bd2e9130a4532488","glsl-optimizer/include/c11_compat.h":"103fedb48f658d36cb416c9c9e5ea4d70dff181aab551fcb1028107d098ffa3e","glsl-optimizer/include/c99_alloca.h":"96ffde34c6cabd17e41df0ea8b79b034ce8f406a60ef58fe8f068af406d8b194","glsl-optimizer/include/c99_compat.h":"aafad02f1ea90a7857636913ea21617a0fcd6197256dcfc6dd97bb3410ba892e","glsl-optimizer/include/c99_math.h":"9730d800899f1e3a605f58e19451cd016385024a05a5300e1ed9c7aeeb1c3463","glsl-optimizer/include/no_extern_c.h":"40069dbb6dd2843658d442f926e609c7799b9c296046a90b62b570774fd618f5","glsl-optimizer/license.txt":"e26a745226f4a46b3ca00ffbe8be18507362189a2863d04b4f563ba176a9a836","glsl-optimizer/src/compiler/builtin_type_macros.h":"5b4fc4d4da7b07f997b6eb569e37db79fa0735286575ef1fab08d419e76776ff","glsl-optimizer/src/compiler/glsl/README":"66a1c12ed7ba0fb63c55ef4559556d2430b89a394d4a8d057f861b8ee1b42608","glsl-optimizer/src/compiler/glsl/TODO":"dd3b7a098e6f9c85ca8c99ce6dea49d65bb75d4cea243b917f29e4ad2c974603","glsl-optimizer/src/compiler/glsl/ast.h":"97fcbc54c28ad4f73dcbf437bcaaf7466344f05578ed72de6786f6a69897bd4e","glsl-optimizer/src/compiler/glsl/ast_array_index.cpp":"92b4d501f33e0544c00d14e4f8837753afd916c2b42e076ccc95c9e8fc37ba94","glsl-optimizer/src/compiler/glsl/ast_expr.cpp":"afd712a7b1beb2b633888f4a0911b0a8e4ae5eb5ab9c1e3f247d518cdaaa56d6","glsl-optimizer/src/compiler/glsl/ast_function.cpp":"67ec8e47a00773c9048778179c4e32e57b301146a433559a2aec008698f6ca8e","glsl-optimizer/src/compiler/glsl/ast_to_hir.cpp":"4f5fd3b906c0cf79e608b28619e900dbc49ad35e04ccf43e809798d8145d13de","glsl-optimizer/src/compiler/glsl/ast_type.cpp":"8eb790b24b26dfb72bdc333744b566c26d8464c5d47d20eae659461f5c4899f7","glsl-optimizer/src/compiler/glsl/builtin_functions.cpp":"9b153e8e2b8e3721a0e0325507c1745afbe7b0c56c2f3b6997dd74197cb889c8","glsl-optimizer/src/compiler/glsl/builtin_functions.h":"a37cad7ed09b522c5b8bec7b80115a36846e7ba6e0874a2a858e32f7f202c665","glsl-optimizer/src/compiler/glsl/builtin_int64.h":"619def6f3aebf180da3944ef08f159ab12a58b24767e41d8b985ac37ded54d62","glsl-optimizer/src/compiler/glsl/builtin_types.cpp":"afec060b62d6f3b00bfbf94e9fa5f96341ce096c128d1eef322791e6ed9cea4d","glsl-optimizer/src/compiler/glsl/builtin_variables.cpp":"8f033c7a6f3f9a4ca6dac9409cd668e30cc7d618dda6e3aa9451465f9e9f587d","glsl-optimizer/src/compiler/glsl/float64.glsl":"fc60780e102a54d97d091518a3bca12159ff4e23c2fc66a5366b359dfaa9e83b","glsl-optimizer/src/compiler/glsl/generate_ir.cpp":"e5f0175370a0d07f93c48d3f0f1b8233d12c64a7b02de02dcc753ef7b398ef0f","glsl-optimizer/src/compiler/glsl/glcpp/README":"a0332a1b221d047e9cce5181a64d4ac4056046fd878360ec8ae3a7b1e062bcff","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-lex.c":"2d179879b1ffe84f58875eee5b0c19b6bae9c973b0c48e6bcd99978f2f501c80","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-lex.l":"e4c5744c837200dafd7c15a912d13f650308ea552454d4fa67271bc0a5bde118","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.c":"36970dd12f54ed02102fbd57962f00710a70a2effccbcbd6caec7625be486e7b","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.h":"5a7158375ecbf6ac8320466c33d534acbe9e60669f5e1908431851dc1ed1f57f","glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.y":"4c9ee9e1fe4e9b96407631e7ec725c96713d1efb1c798538b5e4d02fc8191b9e","glsl-optimizer/src/compiler/glsl/glcpp/glcpp.c":"37ed294403c2abfd17fd999d1ae8d11b170e5e9c878979fefac74a31195c96b0","glsl-optimizer/src/compiler/glsl/glcpp/glcpp.h":"85ac8b444bcbd0822b66448a1da407b6ae5467b649f5afaf5c58325bd7569468","glsl-optimizer/src/compiler/glsl/glcpp/pp.c":"a52d94f1bcb3fb2747a95709c4a77c25de7eea8354d2b83bb18efd96976a4473","glsl-optimizer/src/compiler/glsl/glcpp/pp_standalone_scaffolding.c":"d11aeb3acfe966d1b78f1ee49804093f2434214c41391d139ffcb67b69dc9862","glsl-optimizer/src/compiler/glsl/glcpp/pp_standalone_scaffolding.h":"abbf1f36ec5a92d035bfbb841b9452287d147616e56373cdbee1c0e55af46406","glsl-optimizer/src/compiler/glsl/glsl_lexer.cpp":"272b9fc1383d72b81bfc03fa11fdf82270ed91a294e523f9ce2b4554bd3effa9","glsl-optimizer/src/compiler/glsl/glsl_lexer.ll":"2b57d9f9eb830c3d7961d4533048a158ee6f458c8d05c65bea7b7cfbc36e4458","glsl-optimizer/src/compiler/glsl/glsl_optimizer.cpp":"195487f3d1dca5513712a8c2294f3d684a0e945e6f4e8b7142387f044a5dd7db","glsl-optimizer/src/compiler/glsl/glsl_optimizer.h":"22e843b4ec53ba5f6cd85ca5f7bad33922dca8061b19fb512d46f1caca8d4757","glsl-optimizer/src/compiler/glsl/glsl_parser.cpp":"2a34cbe4afcef6eb0a6a16ea4e920dbad67859cfeefaa1a779991280a5a63e0c","glsl-optimizer/src/compiler/glsl/glsl_parser.h":"a2b79346a0a5b7e75a383f007ac8e07ff85dc12b4ad296d7089e6a01833efec0","glsl-optimizer/src/compiler/glsl/glsl_parser.yy":"91d99418e293cd95dd3ca5c3407b675299904b60de90eb093be248177bdfab3b","glsl-optimizer/src/compiler/glsl/glsl_parser_extras.cpp":"4802ff2208f47849dd6395475e5645e53d696b8cb2ce58e16fb4f86bf9080cb4","glsl-optimizer/src/compiler/glsl/glsl_parser_extras.h":"da52f86890497b7532dd5626f29e1ab12f892ca4d0ade367136f961a9728ffc5","glsl-optimizer/src/compiler/glsl/glsl_symbol_table.cpp":"6660fb83c0ddddbbd64581d46ccfdb9c84bfaa99d13348c289e6442ab00df046","glsl-optimizer/src/compiler/glsl/glsl_symbol_table.h":"24682b8304e0ea3f6318ddb8c859686bd1faee23cd0511d1760977ae975d41bf","glsl-optimizer/src/compiler/glsl/hir_field_selection.cpp":"72a039b0fcab4161788def9e4bedac7ac06a20d8e13146529c6d246bd5202afd","glsl-optimizer/src/compiler/glsl/int64.glsl":"303dbe95dde44b91aee3e38b115b92028400d6a92f9268975d607471984e13eb","glsl-optimizer/src/compiler/glsl/ir.cpp":"0d744d7576e0462fe1db1b7efeff08e7c2b318320a41f47dec70c8e5c7575a25","glsl-optimizer/src/compiler/glsl/ir.h":"e58af2cd704682117173590924f3cec607c2431dcefe005f17d707b734477673","glsl-optimizer/src/compiler/glsl/ir_array_refcount.cpp":"1fde229ea3068d8ef7b9294d294e269931c6dbbcead9a6e7e7cbf36d4a629370","glsl-optimizer/src/compiler/glsl/ir_array_refcount.h":"9ba5f4094805aad4802e406b83bbf7267c14310d0d550b58272d91395349bf1a","glsl-optimizer/src/compiler/glsl/ir_basic_block.cpp":"1e2920b1c0ecb08424c745c558f84d0d7e44b74585cf2cc2265dc4dfede3fa2f","glsl-optimizer/src/compiler/glsl/ir_basic_block.h":"81be7da0fc0ee547cd13ec60c1fcd7d3ce3d70d7e5e988f01a3b43a827acdf05","glsl-optimizer/src/compiler/glsl/ir_builder.cpp":"daba29c5a1efdd5a9754f420eb3e2ebdf73485273497f40d4863dadeddb23c0d","glsl-optimizer/src/compiler/glsl/ir_builder.h":"2822e74dd3f6e3df8b300af27d5b11ea2dd99d0e5e7ca809b7bbcce9833c483c","glsl-optimizer/src/compiler/glsl/ir_builder_print_visitor.cpp":"8c6df5abf2fe313363f285f171c19ca6c8ee4f3bc2ed79d33c0c88cc8be45c48","glsl-optimizer/src/compiler/glsl/ir_builder_print_visitor.h":"799852adc3a0e54d04080655e7cebfa0d3bf5b6ffed5d8414f141380665d4db7","glsl-optimizer/src/compiler/glsl/ir_clone.cpp":"9c2622f3260a120526fb1fdbde70d69de842914e20c29e925373659a2b5c3eaf","glsl-optimizer/src/compiler/glsl/ir_constant_expression.cpp":"21f9d4e2d8e0f423489b18f871e8243472ec79de973ba02ad67b79ce681b492d","glsl-optimizer/src/compiler/glsl/ir_equals.cpp":"bca28533a6310b0fc152b56d80872368f1510dc62ed6e8ac199b9ffa7fac02e7","glsl-optimizer/src/compiler/glsl/ir_expression_flattening.cpp":"7e918d4e1f237eca01396004015865ce345afe32a876c9dbc6728576a1a7eae4","glsl-optimizer/src/compiler/glsl/ir_expression_flattening.h":"f45b66aa9497520e7e08e612d24b308477c34477fbd963ee9320eac664957f16","glsl-optimizer/src/compiler/glsl/ir_expression_operation.h":"d8a94147da73b169a99c95378eecc0570983e1805ad201a773ff1a42d5d50a24","glsl-optimizer/src/compiler/glsl/ir_expression_operation.py":"38bafed32b98ff492cc611514160a39c2e6e17d198b5d290b5727bcd4b55aee1","glsl-optimizer/src/compiler/glsl/ir_expression_operation_constant.h":"8c751e72df480d5c012ebe0ebe25209464b1af32c23e199e4552169c425c7678","glsl-optimizer/src/compiler/glsl/ir_expression_operation_strings.h":"fc9251dcab8e73e00ffc983da3ead3cf32c160eaec1111e23b45eff6f9f4f37e","glsl-optimizer/src/compiler/glsl/ir_function.cpp":"7537365fc0fbe4b37a26b9a2146cc64d3e9a774d60eab63b65002ad165ae8fc7","glsl-optimizer/src/compiler/glsl/ir_function_can_inline.cpp":"faddbf112187a048d502716a3fb82570a322299ba2a3abd79388382c82040bfc","glsl-optimizer/src/compiler/glsl/ir_function_detect_recursion.cpp":"9176973eaf5c0a984701f953bb7a80f37dca43d59b5bce50fc69b3f02f2902d7","glsl-optimizer/src/compiler/glsl/ir_function_inlining.h":"9739493f99c489987d650762fccdd3fb3d432f6481d67f6c799176685bd59632","glsl-optimizer/src/compiler/glsl/ir_hierarchical_visitor.cpp":"c0adaa39f0a94e2c2e7cee2f181043c1fd5d35849fef1a806c62967586a4c3ca","glsl-optimizer/src/compiler/glsl/ir_hierarchical_visitor.h":"0bfe80bbbf9b0f4ae000a333df77fb1cd144a8cda11c29b54c1eabf96f2c351d","glsl-optimizer/src/compiler/glsl/ir_hv_accept.cpp":"caf7ce2cd9494aadd3c58bcf77f29de58368dc9e347a362bbf37f8bda9509b80","glsl-optimizer/src/compiler/glsl/ir_optimization.h":"cd394c803199d96e23a1c9e3f5d2758a5d6645a56c7ec8bd7fe0a6bbe0808351","glsl-optimizer/src/compiler/glsl/ir_print_glsl_visitor.cpp":"1ee46cca6c3562c018614412181c02faf494c92c07d2c7b345d19b355e9b52f3","glsl-optimizer/src/compiler/glsl/ir_print_glsl_visitor.h":"1ad1bd3efd1ace39051c13f904c05fd80425d329444f9a8d47fd6d948faf46e0","glsl-optimizer/src/compiler/glsl/ir_print_visitor.cpp":"066c65b8e181d962ee913388b69c7941362685b66ffe1758abd31b384a96934a","glsl-optimizer/src/compiler/glsl/ir_print_visitor.h":"4573eb93268a2654c14b505253dd651e2695d43dc745904d824da18305269b95","glsl-optimizer/src/compiler/glsl/ir_reader.cpp":"06bfba802c8354e5a8b2334b6d78d6297de18235bedd3f8fbb382c89870b02f2","glsl-optimizer/src/compiler/glsl/ir_reader.h":"63e3f7f1597936a7011d5b520e171b197bf82bee6c1560d822c3edf5aaa6f9e9","glsl-optimizer/src/compiler/glsl/ir_rvalue_visitor.cpp":"84b5c5d746555adca85759c2912fe48010232b7c1c0bd2cf03bd04067a85e66f","glsl-optimizer/src/compiler/glsl/ir_rvalue_visitor.h":"fd8c561b71085d3211fff85ed514fecb299d8ce19a04bc063419a55b6d840525","glsl-optimizer/src/compiler/glsl/ir_set_program_inouts.cpp":"ab9f115ce9e7f312d9c7978340ced0dc4ae6d13a80e08442ba9709d11d50cae5","glsl-optimizer/src/compiler/glsl/ir_uniform.h":"683ae6896b1a08470c090be5f822fc31cd434eab9216e954b9bba24a46975109","glsl-optimizer/src/compiler/glsl/ir_unused_structs.cpp":"15d27cd5ef2748922b8341d7887e6c5bc6d1f4801c36d25c769e48d364342398","glsl-optimizer/src/compiler/glsl/ir_unused_structs.h":"13387b49c23093575276b25b9dfd31fedd8f131c5c4f3128ab04cf03e15b5295","glsl-optimizer/src/compiler/glsl/ir_validate.cpp":"bded6922c63173e7cb15882bd7fd0e25b9a478c4223fc0ffcfd0890d137f4ed1","glsl-optimizer/src/compiler/glsl/ir_variable_refcount.cpp":"2764a3cad937d53f36db7447c3a5b98b04bf153acf81074d971857fc5bca460d","glsl-optimizer/src/compiler/glsl/ir_variable_refcount.h":"b0668e3eb1501ef65e38fe12830742ecb3d28e6039f30e366c8924efc29b4a39","glsl-optimizer/src/compiler/glsl/ir_visitor.h":"f21b3534c3d66d5fb707d1581fece7e1eb043523afbaedf89918cfb031c6df94","glsl-optimizer/src/compiler/glsl/link_atomics.cpp":"360f0209e11f367ba358223597b0a118bae095bff16337cf03f1fb89c5b80ca6","glsl-optimizer/src/compiler/glsl/link_functions.cpp":"de7895da8aa33a1e3c2c1eb2fdaf267ab5d1fbfdb79ae2e67f95211e946e294c","glsl-optimizer/src/compiler/glsl/link_interface_blocks.cpp":"1926cfa73810704eb19b916c1b2cdb9321155e2f98b2a0a57c7c3c6e960540cd","glsl-optimizer/src/compiler/glsl/link_uniform_block_active_visitor.cpp":"1e14e06ca3b2c1089cfba2e8eaf0c1f373d9d6374b6082f320962dd71ae09611","glsl-optimizer/src/compiler/glsl/link_uniform_block_active_visitor.h":"fd58c155af645295bb6aec08797889de586f4d919731de2bce57e8dce59bb048","glsl-optimizer/src/compiler/glsl/link_uniform_blocks.cpp":"09589f49776dce32e6c4044937de7e0c839a9754ad31960148f8f9e010658997","glsl-optimizer/src/compiler/glsl/link_uniform_initializers.cpp":"bf98e08c12db466acf9623cbeb8fa8e3b4002512722e7a6521287f558a099f37","glsl-optimizer/src/compiler/glsl/link_uniforms.cpp":"84bad5b1377362cecf259b05124239be5220b03ce1c0c61b59bd9a47e4379af2","glsl-optimizer/src/compiler/glsl/link_varyings.cpp":"09e6a9395f142d6029e8d58cd993685f2bed35125d193a39bc7c96ec6ebed6f8","glsl-optimizer/src/compiler/glsl/link_varyings.h":"44a1270f8ed61cab8481358c7342943958618bb5057cd342369373b79c74abd0","glsl-optimizer/src/compiler/glsl/linker.cpp":"dcfbfab55f31c81afc90aec7d0a1620a80a4a9eea642efb20a99eaafc32ba95b","glsl-optimizer/src/compiler/glsl/linker.h":"ecf94b4ad75ef461c27c557fda4bd25f34c91930822b8e1d729ec84520d4a049","glsl-optimizer/src/compiler/glsl/linker_util.cpp":"6bef0fd8438c4de02140e93e1af6855e56f7aed6f9dbcb820e54bbaa4ae0eb6c","glsl-optimizer/src/compiler/glsl/linker_util.h":"462a266538ba9812f96ac9226519ba3b2e54ff794adee60c143e8676c5c047d8","glsl-optimizer/src/compiler/glsl/list.h":"8fffadc41788723420e6b4c1c19b6e400682fe72d458f4a0aedcb600b9404dfb","glsl-optimizer/src/compiler/glsl/loop_analysis.cpp":"57ecd573477c68091c7cc99537faa7139a8f395935e3d4f10144cefdefb5a611","glsl-optimizer/src/compiler/glsl/loop_analysis.h":"a85f045a038ee5b5176063e85d7988865862c44ab0580f771b993a042d0b69cc","glsl-optimizer/src/compiler/glsl/loop_unroll.cpp":"bd4292ea2809f5a669bcb76ceaa1ac365772dcd638c579c3ed10275214901a54","glsl-optimizer/src/compiler/glsl/lower_blend_equation_advanced.cpp":"8cfbef140d9c4b4d2f57bfa05c9c374d31a121d0f87afce94333f049023b654a","glsl-optimizer/src/compiler/glsl/lower_buffer_access.cpp":"1ae221c3c7a95aeb867207e7a742be635f91b406c157747bfd6ddf10274d97fb","glsl-optimizer/src/compiler/glsl/lower_buffer_access.h":"807886953a576a323591798cbca5e2df24295ea893b28affd8ffb5926cebaa04","glsl-optimizer/src/compiler/glsl/lower_const_arrays_to_uniforms.cpp":"608403f0eeeedf21cfcd3014116e0f44e28cbdf6c4c32aac7e613e64e30205e1","glsl-optimizer/src/compiler/glsl/lower_cs_derived.cpp":"179905cd47a294122adeb5b0abfed6f2f67782dcde21b544d1ee2c1985154e66","glsl-optimizer/src/compiler/glsl/lower_discard.cpp":"3b361b2db0004d544d64611cb50d5a6e364cf6c5f2e60c449085d7d753dd7fb0","glsl-optimizer/src/compiler/glsl/lower_discard_flow.cpp":"f5c29b6a27690bb5c91f196d1a1cf9f6be4f1025292311fe2dac561ce6774dee","glsl-optimizer/src/compiler/glsl/lower_distance.cpp":"a118c85493d5d22b2c059a930c51a5854896d4b1dade76598eaa985e5a3dff8c","glsl-optimizer/src/compiler/glsl/lower_if_to_cond_assign.cpp":"469e617757fd1728709cce021aac5c8da05ee503bf5366977bdc4ef7a6d83950","glsl-optimizer/src/compiler/glsl/lower_instructions.cpp":"39dc7589b56758884cb322287d8bb8cd81d3bd8986fadc9fd4d68bf422b1f281","glsl-optimizer/src/compiler/glsl/lower_int64.cpp":"d1ed41196880dd53c7b13e2782f9423f8442bf1d46186e8be92b1b66218a83ee","glsl-optimizer/src/compiler/glsl/lower_jumps.cpp":"f638ef8eaec462bc2ce4b1874f59c66aeed24774dfdd7e9fe2b5eab7206e4524","glsl-optimizer/src/compiler/glsl/lower_mat_op_to_vec.cpp":"33d55d38cbe4af8e345765214303d5ace282e024992e7a9420f4338b9a4d1e34","glsl-optimizer/src/compiler/glsl/lower_named_interface_blocks.cpp":"16063ac127bff75a68272070ab11c21c25101edbff62b4c68f4983b4cd941af0","glsl-optimizer/src/compiler/glsl/lower_noise.cpp":"cfdf639cdf5a1f76a7a73234e1bf0c72e5d2089cac44a6663c2012b7f99431af","glsl-optimizer/src/compiler/glsl/lower_offset_array.cpp":"3b00773399135aea85746a5a68b96ef000bc6841be1a2c8e6f25c516628b0949","glsl-optimizer/src/compiler/glsl/lower_output_reads.cpp":"a0fc9975d5aa1617e21fc6c353659a9802da9e83779a3eef4ec584f74b4dadc5","glsl-optimizer/src/compiler/glsl/lower_packed_varyings.cpp":"2cfecd9e8e12603ce8038db74c9dac0dcb7fb77f6ec34baf76896dc235e214bd","glsl-optimizer/src/compiler/glsl/lower_packing_builtins.cpp":"79a13d161fe505a410ab948d92769395708693ec888153630fa240e5b97e356f","glsl-optimizer/src/compiler/glsl/lower_shared_reference.cpp":"ea2dccf50a83bc19391bf6b7ab6aa53c0005f427af4066d25140340af9a4beef","glsl-optimizer/src/compiler/glsl/lower_subroutine.cpp":"f69fa53650eeb6f2944fce4d36a6e0a423e6705f3a3bd3389c7fadb83cfc8802","glsl-optimizer/src/compiler/glsl/lower_tess_level.cpp":"b196c9d424c0569f3e85d75c2d125af21566cb113d69036db87c0990703e0fa7","glsl-optimizer/src/compiler/glsl/lower_texture_projection.cpp":"4d247f244272adc8250fd888d8d932a140dd5de4d1efc7a58492c3c2b8291527","glsl-optimizer/src/compiler/glsl/lower_ubo_reference.cpp":"89bdbc6c1669230c644c0857db1ce2781ec61d349ecd08c7914146e1f4750a4a","glsl-optimizer/src/compiler/glsl/lower_variable_index_to_cond_assign.cpp":"fce930f29ac9405b297d1f749d68f59506b89c70b4ee1b1ab8cf49a34cc71ecf","glsl-optimizer/src/compiler/glsl/lower_vec_index_to_cond_assign.cpp":"3c67d851a11a55fad1c49a550f3a0cfe50892d33a3f238ce266cd829eba510a8","glsl-optimizer/src/compiler/glsl/lower_vec_index_to_swizzle.cpp":"f5ec666b73e1415cbab32519a53605ed385f3b03e889560373dbce69dda5000e","glsl-optimizer/src/compiler/glsl/lower_vector.cpp":"f7c13f5572ebe09b6a71553133b2cf003cd4b77b9657600672ee3b21bf890725","glsl-optimizer/src/compiler/glsl/lower_vector_derefs.cpp":"b05793da6dd620a531b43df5af8b2ecbc37b9db0c88910f5724ea10bcd057e19","glsl-optimizer/src/compiler/glsl/lower_vector_insert.cpp":"fee772ec17eea5e86a529bf9c5fa2ee0d29a5982bb75ebc6d68ed36cd19aa299","glsl-optimizer/src/compiler/glsl/lower_vertex_id.cpp":"690e8715182e03fead5cc5a35251fb4f41b357e4c71a1dfbc4bd7be19862b56d","glsl-optimizer/src/compiler/glsl/main.cpp":"d9d3841884a388a57e0adcd6b830ea59fb3fb7c5d78f2c0796f11d4ce3c9f96a","glsl-optimizer/src/compiler/glsl/opt_add_neg_to_sub.h":"f5054944bfd068810629080d0ea11df78b3f57a8f86df75e13ca50157ad1964d","glsl-optimizer/src/compiler/glsl/opt_algebraic.cpp":"121d58ee9dd11e3fffca31d8a1a3f3abcf80aed174a2c740986bbd81cdeb0e6d","glsl-optimizer/src/compiler/glsl/opt_array_splitting.cpp":"19d3ce0e815438f4df9ab2890e767b03a4f3f191b53bb30c0217cf2ae6a95430","glsl-optimizer/src/compiler/glsl/opt_conditional_discard.cpp":"0e44e0e126711a3725c1f3a2aa65ff03c381fed08680ffc30101aae60f716c4e","glsl-optimizer/src/compiler/glsl/opt_constant_folding.cpp":"a088d04d9b45f9e55e235835648f614c89b7803c03a6d4f6a6d1a6bc1f0228bd","glsl-optimizer/src/compiler/glsl/opt_constant_propagation.cpp":"710109a6249858e7cf764dbbf695836e0fe421f8a651e067fb989974e7b474ff","glsl-optimizer/src/compiler/glsl/opt_constant_variable.cpp":"4a395474e9a8aa45b84b6b683c7783791400a30e75a6814d3fbb722d85c12aa2","glsl-optimizer/src/compiler/glsl/opt_copy_propagation_elements.cpp":"ffa0f50863995e0d2e31f55a52e82319edc71e520987bebd7f7e561ea331c64b","glsl-optimizer/src/compiler/glsl/opt_dead_builtin_variables.cpp":"84e8747b948232f01dd56b428b9315f96f9511f605f240119fc446fae28981a9","glsl-optimizer/src/compiler/glsl/opt_dead_builtin_varyings.cpp":"761523e88f5b3ba785170f4d7205e94fa99acb7e74d29efbe40e1c010e1dbdb3","glsl-optimizer/src/compiler/glsl/opt_dead_code.cpp":"fd1ba2da7337d4e5dad17f5c2d73d9cc8880305f423e85d64cf94553588fa401","glsl-optimizer/src/compiler/glsl/opt_dead_code_local.cpp":"bfc0b6d5a42d80c9c6b57130d3322b6940b4a02021488f4aeef489b2c3652a7a","glsl-optimizer/src/compiler/glsl/opt_dead_functions.cpp":"774cae6536d02edf26e996a2a895e1f62d5098f16dc96b44798b4fc731a9a95f","glsl-optimizer/src/compiler/glsl/opt_flatten_nested_if_blocks.cpp":"3696a5c55f02e20056e085bc2714f73ac992f221b6f3387d655068e86b512046","glsl-optimizer/src/compiler/glsl/opt_flip_matrices.cpp":"44f0fe05b49329667671f88c96dc86ab3fe1459ff7b87f2b2d88de2d49829f9f","glsl-optimizer/src/compiler/glsl/opt_function_inlining.cpp":"fb56a33c90419a01676b57cbd91d0674a54cca40e6defaacc88dd33facebc131","glsl-optimizer/src/compiler/glsl/opt_if_simplification.cpp":"ac406eb35e379c357641d6c5749f50c65961455924d3dc884e2b90046fa92c5c","glsl-optimizer/src/compiler/glsl/opt_minmax.cpp":"27c6c5357043b5c6e5d594d7476e9a00e8f6db033a86f5c984243f44ed492430","glsl-optimizer/src/compiler/glsl/opt_rebalance_tree.cpp":"8bb6329dc0f299042368fc81934c2df019b45ab9f7aa0415d4e57b8d1ff98c9f","glsl-optimizer/src/compiler/glsl/opt_redundant_jumps.cpp":"222c73e2ac7a938ebb6428cc6c780c908ff6156d8ff935b04fed93a48fc10496","glsl-optimizer/src/compiler/glsl/opt_structure_splitting.cpp":"2edc79cc13f3177934e0443ad62f5976a1991f01f86ea303a803434849b13a47","glsl-optimizer/src/compiler/glsl/opt_swizzle.cpp":"015d0abddfe507f67c4b96c82988d861d018ededf7bf055e2bcbe9ea92da694e","glsl-optimizer/src/compiler/glsl/opt_tree_grafting.cpp":"46d28ac983ea244a4315bdc0e8892979ec4d1f9b9a96ac8a8a08006d9bc5e878","glsl-optimizer/src/compiler/glsl/opt_vectorize.cpp":"d80ee43bb97d9f016fb9c5e1e06f5b2afa569811f368ba067be794ec11d085fb","glsl-optimizer/src/compiler/glsl/program.h":"2982447e2abd35371e273ad87951722782a8b21c08294f67c39d987da1e1c55f","glsl-optimizer/src/compiler/glsl/propagate_invariance.cpp":"080943e21baa32494723a2eefb185915d2daae1f46d6df420145c5ad6857e119","glsl-optimizer/src/compiler/glsl/s_expression.cpp":"1ced972bc6ecc8eab4116ea71fb0212ab9ae5bcc0be3b47aa5d9d903566b3af1","glsl-optimizer/src/compiler/glsl/s_expression.h":"65b847e30e22a809b57d0bc70243049c99d9c6318803c5b8d0826aba55dc217e","glsl-optimizer/src/compiler/glsl/serialize.cpp":"d57addf5e72954a98192a09287f5013a86a802b763112ab88b6595a356384864","glsl-optimizer/src/compiler/glsl/serialize.h":"57425732eba1233d928e5f07f88b623ce65af46b3bb034bf147f0a4b7f94f9a1","glsl-optimizer/src/compiler/glsl/shader_cache.cpp":"e0c5c433f2df3fccdf1d61281bfcb0ee5633433339b97c697d64db99611cbaaf","glsl-optimizer/src/compiler/glsl/shader_cache.h":"9217164d8d7f54aca0fe5922c7187095a6ae0cb703b196b79805aeef07a7e697","glsl-optimizer/src/compiler/glsl/standalone.cpp":"37e5566b2a20ab8a9f2262735a37598482816abec3e348221d8d95c5a2762aa1","glsl-optimizer/src/compiler/glsl/standalone.h":"788d6a39b6b93a7ed6eafa2c8f9c439ac84aeddb7545f3d4381af29bd93aaa2e","glsl-optimizer/src/compiler/glsl/standalone_scaffolding.cpp":"f71ba2958c75f1504ea6ef56d6ccdc3c0ea291cac38513978fa0b8bee1595e96","glsl-optimizer/src/compiler/glsl/standalone_scaffolding.h":"d921a617ea82b9e49413314492a645c44356de503581b1be3f1b57de236e480d","glsl-optimizer/src/compiler/glsl/string_to_uint_map.cpp":"d824bf5b839bd39498dc9e457103cdbe3e5289ddf7564107c27b1505948dd31f","glsl-optimizer/src/compiler/glsl/string_to_uint_map.h":"e2f18e66359c9d620e085de7f4a334a47df9c66e65a5bfe8b734c627bec04104","glsl-optimizer/src/compiler/glsl/test_optpass.h":"b27b8f35f5387e7ce4982bb51c7b63ccf14f91757f3108a5d02ed006925bb8a0","glsl-optimizer/src/compiler/glsl/xxd.py":"376484142f27f45090ea8203ae2621abf73f06175cb0ee8d96f44a3b9327f4bd","glsl-optimizer/src/compiler/glsl_types.cpp":"61664f65ecf47c9787f71020050bcef67215afe2885b9b4656bbd2f9b2b575b5","glsl-optimizer/src/compiler/glsl_types.h":"3c9f573559192c1c339af967cd65224be54c9e05cc4758b2ffac9b0b7485c88f","glsl-optimizer/src/compiler/shader_enums.c":"f97a3b1b07ef70b387e540b538af8073fe5f7ffb591515e3abf913acdd7f34bc","glsl-optimizer/src/compiler/shader_enums.h":"9681494cb850bd4ccd1fd18471af00456d68122dcc40a916fb061c6d6ed4854a","glsl-optimizer/src/compiler/shader_info.h":"457bdf6409ab07a154ef172c65380d4973e7cb11d14d36a6d7b3b7c66e2edd2f","glsl-optimizer/src/gallium/auxiliary/util/u_half.h":"a4e2ddd24cf9a1e04f18765dbc29d5acf1a3f71da77a91b034fd0e3a7d047268","glsl-optimizer/src/gallium/include/pipe/p_compiler.h":"587317125c88baa3a562fa9a1985f905a2f47922af29d23b86b78117d08790b4","glsl-optimizer/src/gallium/include/pipe/p_config.h":"a27692fc35f9e55df3224b7529e66b3001e911e94e6bc5f8f569e493e1ee3fb7","glsl-optimizer/src/gallium/include/pipe/p_format.h":"d15e7fbe83174e0e0122e25a1720dda487cbe5776b764ce71055512922088f10","glsl-optimizer/src/mapi/glapi/glapi.h":"73632a625c0ddabc401205e8b5a81eb8af8506868efe4b170d7979ec3619e9c5","glsl-optimizer/src/mesa/main/compiler.h":"79e3bf40a5bab704e6c949f23a1352759607bb57d80e5d8df2ef159755f10b68","glsl-optimizer/src/mesa/main/config.h":"5800259373099e5405de2eb52619f9de242552a479902a3a642a333c8cb3c1e7","glsl-optimizer/src/mesa/main/context.c":"02c18b693312dc50129d66e353220df736cba58a0faaa38316d861025441e78a","glsl-optimizer/src/mesa/main/context.h":"407bddf4a338a0a65f9317e3d076910502d43c948c8a6b7e700e55212fdc155b","glsl-optimizer/src/mesa/main/dd.h":"845ead03db94fab79c7b8e3155bb9c795d1a91b10857a745afc666046e077e4f","glsl-optimizer/src/mesa/main/debug_output.h":"7312422e90b8c0e34028ac27280e438139b5cba525c99deb3ac883cd3d87e452","glsl-optimizer/src/mesa/main/draw.h":"3f5fea0fe2fc5e6fa8db4f4db2481a5d2c683a500ac290d946b063ddf579fd74","glsl-optimizer/src/mesa/main/enums.h":"87d562a6764f51c014a2274fa7c3aca17c04441537ddd56b2554f13c6fffea92","glsl-optimizer/src/mesa/main/errors.h":"c79444b5df289c90fbb22a33b2d0c23917d9fc4510960088f0b79e53bb56b1b2","glsl-optimizer/src/mesa/main/extensions.h":"483fe6654938ce1c8e8ded5dde2eefd2710fcf4dade37fb9c8d08c128f362113","glsl-optimizer/src/mesa/main/extensions_table.c":"17642d1a8c9a0bf2bd61060052d33ff14a005d2b962e6cf91465797a50851e85","glsl-optimizer/src/mesa/main/extensions_table.h":"d78d97a1df035a9d7562cec0cc6feadf79888b2eebc79336f3eb3e73321ee2ce","glsl-optimizer/src/mesa/main/formats.h":"a45bb586e2f990b906e605b7233c51389e72dfa7cd33fb220f21d78c4edcd18e","glsl-optimizer/src/mesa/main/glheader.h":"58217b33eead6aa6b23cd4a291cefeaa6cb84e465f4960daffca97c44d6d1c35","glsl-optimizer/src/mesa/main/hash.h":"5ea00760025c688cf81ba25cb99ebcfcd2c79091d44fc5b6257b4876d11ea04e","glsl-optimizer/src/mesa/main/imports.c":"c102235731498dfb7204f753c9e650daaf9e4609ba5d85aafdaca994c7b88325","glsl-optimizer/src/mesa/main/imports.h":"31634703de1e30bc3e40d63dac4055ae025a608ceaf3c9da5d64c8c5e9a31fb2","glsl-optimizer/src/mesa/main/macros.h":"fc04dd953826c9ff1b2850fbeaa2a6c59c964450b4923f52e3425e7c4f58b085","glsl-optimizer/src/mesa/main/menums.h":"5dfac0e2279d60b0cd0c7b9fc2a5021620d0f6282ed2e738c420214e3af152d3","glsl-optimizer/src/mesa/main/mtypes.h":"69eebf3ed20da8042fce544f92ad81454234d5968e6f9a9c4db38184fefbad3f","glsl-optimizer/src/mesa/main/shaderobj.h":"9f0dfe96d0c2154201adef942bd36053533ac7b2492fb3786acda5bea514c75e","glsl-optimizer/src/mesa/main/uniforms.h":"4e331e6ad6e9cbded978b4082dbe0a57c1f8f01327446bb6892bfc179976c38b","glsl-optimizer/src/mesa/main/version.h":"9d0a13a758099302dc55cf7d045791834a89b0f9d4cf17b2692259b369a8a9a1","glsl-optimizer/src/mesa/math/m_matrix.h":"a37b19f182e070db3df93b0ede43c22fb8be8c2906504133ee6dbd7db1185d8b","glsl-optimizer/src/mesa/program/dummy_errors.c":"1820e305515b4c5e041f5e1623266a48ec8f076a155310be7d60637101f593e4","glsl-optimizer/src/mesa/program/ir_to_mesa.h":"b47f58d22e3ca2ae42d52501ea769d15c4476834944fa97eeccd3a3439211d00","glsl-optimizer/src/mesa/program/prog_instruction.h":"ab3832152a7e144b59e5a2264b2c29db56d93be31e76bbd958527a56771b40eb","glsl-optimizer/src/mesa/program/prog_parameter.h":"2211768d6458b21f84c3a58083a92efe52a9902ece92a23ee83184c3a3a2e16a","glsl-optimizer/src/mesa/program/prog_statevars.h":"fc413698f84bc52d45fdeae0471934ee9904bfb7eac1a2b5f70446e54bcbbdca","glsl-optimizer/src/mesa/program/program.h":"f61c9d123f28c7ff8b390648d35f329e7b6e68e33823239d539b7be8384541bb","glsl-optimizer/src/mesa/program/symbol_table.c":"f275a98f1afc91399a14dbbc5a9d222bdf6e21764c7b83ec688962b40caece91","glsl-optimizer/src/mesa/program/symbol_table.h":"631dc35ac48d5e87962d45507461920f6575610960ffcc42a08cefeb43300cda","glsl-optimizer/src/mesa/vbo/vbo.h":"b9bf5ad54267cfd7af2e842dda029090dcc7db1c5b7825914736c3c132909d95","glsl-optimizer/src/util/bitscan.h":"d4fcb47b57a50d70cb97f99ca3e619bc06282a877768a435e009775ce8d77f36","glsl-optimizer/src/util/bitset.h":"c40f78515c6230fed18345c6751ce33833a49da7a27901c7e6d7340cbdcbc5e7","glsl-optimizer/src/util/blob.c":"214fea1499bc25eed6eb560651f3358cadbaf507b4ec8bdb8f894c13010ab3f5","glsl-optimizer/src/util/blob.h":"093d5dc1acbd424eaaf8e48d6735d4c4acf8d5d48d7226fa21c249e32f0108aa","glsl-optimizer/src/util/crc32.c":"2f3467a046b3a76784ecb9aa55d527698c8607fd0b12c622f6691aaa77b58505","glsl-optimizer/src/util/crc32.h":"59bd81865e51042b73a86f8fb117c312418df095fed2d828c5c1d1c8b6fc6cd4","glsl-optimizer/src/util/debug.c":"4e307954f49d9700a99510684f930a8e404c8e1078f5a774f9245711e963fe9a","glsl-optimizer/src/util/debug.h":"50068d745c4199ccbd33d68dd4c8a36d2b5179c7869a21e75906ddd0718ca456","glsl-optimizer/src/util/detect_os.h":"343a8790d17a3710c6dd015ee367f84e3902ff3f2e36faca2bf93f9d725d3574","glsl-optimizer/src/util/disk_cache.c":"c963a961597ce5c1de98424f38b3a4163c8479410539bbe1bc142c06b2b5e1d1","glsl-optimizer/src/util/disk_cache.h":"e83314fb14134a8e079b15e470a6376ba5a8253701f048c890a62b7e55d64bc8","glsl-optimizer/src/util/fast_urem_by_const.h":"e108fce804616c47d071dfe4a04163eec1126e448ed1aa89abb6b3a6d772bd5b","glsl-optimizer/src/util/fnv1a.h":"ab2596f19c6adf431ae27618f62c5743e24ad23ef83bb359a4c4c218245ab459","glsl-optimizer/src/util/futex.h":"fae18b3385e7bd683e06c399aae64428c92133bb808e5c04d957dfea0c466910","glsl-optimizer/src/util/half_float.c":"11bc2584493d5d9d46e8c8a619a0307cf150bf5ab5d0f96bb764b061dc37a00e","glsl-optimizer/src/util/half_float.h":"698a6d628c38244ef816cf69dda6e3cc7341725956e990bddde11a11e2565330","glsl-optimizer/src/util/hash_table.c":"f8b81f85ae418f9ee5b077bdbfafde708325357bcbb75cb04924316d629c7a8f","glsl-optimizer/src/util/hash_table.h":"217191bb360592e2232f187473c10287d2cda8ae6fa5c53d0ef74c8c206118b4","glsl-optimizer/src/util/list.h":"9fab03c6a78186bb5f173269f825f6ce976b409d931852e3d93bac632e07989a","glsl-optimizer/src/util/macros.h":"5057bb77c9ffec4ccdb4fb4640dd6eb05caf549e8665ea4afb5ba1142a4a5a17","glsl-optimizer/src/util/mesa-sha1.c":"00c692ec353ebc02c06c57c5a71de0ab7a119f86a4146f452e65ec87e4944417","glsl-optimizer/src/util/mesa-sha1.h":"bff4c29f4bf7cdbcefb30fa0c996a7604a380eba8976467c2a60e7cd328f7e26","glsl-optimizer/src/util/mesa-sha1_test.c":"25da89a59d51469f77b4c468ca23ffdce0a7a1166a70b6cc23026a6800b0143c","glsl-optimizer/src/util/ralloc.c":"691183679ceb2f1e0fbfe0669f5accd239ceb3449df7586c7269b011765fdc35","glsl-optimizer/src/util/ralloc.h":"e573c45875ff1530f0dbee9a93ae55535fdac8d5cc88a79ebc327c688824bde5","glsl-optimizer/src/util/rounding.h":"bee6e21354e569c58f0b34a34351903394f6ad890391dd9c8025a399891912e1","glsl-optimizer/src/util/set.c":"a71293beff2fc7da6ca4118f89e8758d024571049207db3d2491084cafa8a3a5","glsl-optimizer/src/util/set.h":"3e39ca161e7ed4ec7c436cc9c7919ed9a55ed1b71edbf2caf6f9bcfd9bc578ed","glsl-optimizer/src/util/sha1/README":"00af7419af05247081858acb2902efd99fcda2ce16e331079f701645bb3729c0","glsl-optimizer/src/util/sha1/sha1.c":"1403bbe0aad42ba3e6be7e09f7cad87a6a8c4ad5b63962f7b92b9f37d8133b04","glsl-optimizer/src/util/sha1/sha1.h":"68d9f240eab2918026ecdf22be36811abbd4f1389f6c36e31258041aeaedd247","glsl-optimizer/src/util/simple_mtx.h":"46dcc6a53a682cacd1e093950d37b2f2715865bc88c030ae8120ec76907578e2","glsl-optimizer/src/util/softfloat.c":"a97e51a96fe5e6a052c02aa6bbec683fe73fb88a8c087d9c930503e2120d8a2e","glsl-optimizer/src/util/softfloat.h":"66664b0250e83bf5dd4cc743acd119d076efcea624a0eab3d6b60718e6ee8811","glsl-optimizer/src/util/string_buffer.c":"63a1d1b1e34926c88ea00159cafbcd56568b805c4f64d1e8c97169fe313921fc","glsl-optimizer/src/util/string_buffer.h":"7b88d1b1d9c6cfb8e93331813535c127289437c75f822029e9a3bca8ea6b52ee","glsl-optimizer/src/util/strndup.h":"0273c4fdb7482cd7746881a63d3998648c6d63415ba85af1d1860f0e0dc504c6","glsl-optimizer/src/util/strtod.c":"5cf610d8a37373cf37cfb7aae903525d943b2674b1f32594c70b0eb19a8c9697","glsl-optimizer/src/util/strtod.h":"237396def4e264d35ed4bedea00ef9a4ceab6d7a11a18c770d9747d22c69ed2d","glsl-optimizer/src/util/u_atomic.h":"c02e809526c6c09ba8fe51f50b2490d1b6c8e5c7f3c4031ae958250d098fc3bb","glsl-optimizer/src/util/u_dynarray.h":"853d0fa6ff2261614488be624deb8a2b01e57c2c8eabc28578cbeed4ccc95694","glsl-optimizer/src/util/u_endian.h":"3ccea7e529740318d8a4b05c00db3adc9d1e292a52bdc56a05c9fae99209720f","glsl-optimizer/src/util/u_math.c":"c868a8c0886dc78f1b06b13404ba8b253090449045774dd56893ac9d75795184","glsl-optimizer/src/util/u_math.h":"57e7411c1afc06c43c1f087dc8de9ffe99ee0a67d28d40d8a87489aecffa9a0e","glsl-optimizer/src/util/u_string.h":"8bbc5f0d81cd482bf0aa201e95eb1c6ab3d6dfcb47c1c440e0c2fe5730cee14d","glsl-optimizer/src/util/xxhash.h":"2f2aff2fc6c0c929f52cf6ae7314122124c5be026d41ad1c357608383c4a37ad","src/bindings.rs":"79993db2058bde39f99ef483d02560d33b1cb882f6a552319e8b86eb6f9021e1","src/lib.rs":"04be1554cd829eb40864b06d80b491dd48117a4e3a601c7d482117f7a0391e67","wrapper.hpp":"f3ea34cc496f7d90b9bfcada3250b37b314c3524dac693b2ece9517bc7d274ac"},"package":"f22b383fcf6f85c4a268af39a0758ec40970e5f9f8fe9809e4415d48409b8379"}
+diff --git a/third_party/rust/glslopt/build.rs b/third_party/rust/glslopt/build.rs
+index 0e3c759e8220..8cf2ec3df416 100644
+--- a/third_party/rust/glslopt/build.rs
++++ b/third_party/rust/glslopt/build.rs
+@@ -1,6 +1,10 @@
+ use cc;
+ 
+ use std::env;
++use std::process::Command;
++use std::path::Path;
++use std::io;
++use std::io::Write;
+ 
+ /// Adds the required definitions to build mesa/glsl-optimizer for the
+ /// target platform.
+@@ -19,6 +23,117 @@ fn configure(build: &mut cc::Build) -> &mut cc::Build {
+     build
+ }
+ 
++fn is_486_target() -> bool {
++    let mut is_486_target = false;
++    match env::var("TARGET") {
++        Ok(val) => is_486_target = val == "i686-unknown-linux-gnu",
++        Err(e) => {},
++    }
++    return is_486_target;
++}
++
++fn is_486_sb2() -> bool {
++    let mut is_486_sb2 = false;
++    match env::var("SB2_TARGET") {
++        Ok(val) => is_486_sb2 = val == "i686-unknown-linux-gnu",
++        Err(e) => {},
++    }
++    return is_486_sb2;
++}
++
++fn compile(tool: &str, includes: &[&str], file: &str) {
++    let out_dir = env::var("OUT_DIR").unwrap();
++    let path = Path::new(file);
++    let path_out = format!("{}/{}", out_dir,
++        &path.parent().unwrap().to_str().unwrap());
++    let file_out = format!("{}/{}.o", path_out,
++        &path.file_stem().unwrap().to_str().unwrap());
++    let magic_include = format!("{}/../../../../include", out_dir);
++
++    // Ensure we have an output directory
++    Command::new("mkdir")
++        .arg("-p")
++        .arg(&path_out)
++        .status()
++        .unwrap();
++
++    // Compile file.c into file.o
++    let mut command = Command::new(tool);
++    command
++        .args(&["-isystem", &magic_include, "-O0", "-ffunction-sections", "-fdata-sections", "-fPIC", "-g", "-fno-omit-frame-pointer", "-m32", "-march=i686"]);
++
++    for i in 0..includes.len() {
++        command.arg("-I");
++        command.arg(includes[i]);
++    }
++
++    command
++        .args(&["-D__STDC_FORMAT_MACROS", "-DHAVE_ENDIAN_H", "-DHAVE_PTHREAD", "-DHAVE_TIMESPEC_GET"])
++        .args(&["-o", &file_out])
++        .args(&["-c", file]);
++
++    println!("####################### Compiling: {}", file);
++    println!("Build command: {:?}", command);
++
++    let output = command
++        .output()
++        .expect("Failed to execute compile process");
++
++    println!("Compile status: {}", output.status);
++    println!("######## stdout:");
++    io::stdout().write_all(&output.stdout).unwrap();
++    println!("######## stderr:");
++    io::stderr().write_all(&output.stderr).unwrap();
++    println!("#######################");
++
++    assert!(output.status.success());
++}
++
++fn archive(files: &[&str], archivename: &str) {
++    let out_dir = env::var("OUT_DIR").unwrap();
++
++    // Archive it all up
++    let mut command = Command::new("ar");
++    command
++        .args(&["cq", &format!("lib{}.a", archivename)])
++        .current_dir(&Path::new(&out_dir));
++
++    for i in 0..files.len() {
++        let path = Path::new(files[i]);
++        let path_out = format!("{}/{}", out_dir,
++            &path.parent().unwrap().to_str().unwrap());
++        let object_file = &format!("{}/{}.o", path_out,
++            &path.file_stem().unwrap().to_str().unwrap()).clone();
++
++        command.arg(object_file);
++    }
++
++    command
++        .status()
++        .unwrap();
++
++    Command::new("ar")
++        .args(&["s", &format!("{}/lib{}.a", out_dir, archivename)]);
++
++}
++
++fn build(tool: &str, includes: &[&str], files: &[&str], archivename: &str) {
++    let out_dir = env::var("OUT_DIR").unwrap();
++
++    for i in 0..files.len() {
++        compile(tool, includes, files[i]);
++    }
++    archive(files, archivename);
++
++    // Ensure cargo knows where to find the results
++    println!("cargo:rustc-link-search=native={}", out_dir);
++    println!("cargo:rustc-link-lib=static={}", archivename);
++    // Ensure changes propagate
++    for i in 0..files.len() {
++        println!("cargo:rerun-if-changed={}", files[i]);
++    }
++}
++
+ fn main() {
+     // Unset CFLAGS which are probably intended for a target build,
+     // but might break building this as a build dependency if we are
+@@ -29,170 +144,355 @@ fn main() {
+     env::remove_var(format!("CFLAGS_{}", target.replace("-", "_")));
+     env::remove_var(format!("CXXFLAGS_{}", target.replace("-", "_")));
+ 
+-    configure(&mut cc::Build::new())
+-        .warnings(false)
+-        .include("glsl-optimizer/include")
+-        .include("glsl-optimizer/src/mesa")
+-        .include("glsl-optimizer/src/mapi")
+-        .include("glsl-optimizer/src/compiler")
+-        .include("glsl-optimizer/src/compiler/glsl")
+-        .include("glsl-optimizer/src/gallium/auxiliary")
+-        .include("glsl-optimizer/src/gallium/include")
+-        .include("glsl-optimizer/src")
+-        .include("glsl-optimizer/src/util")
+-        .file("glsl-optimizer/src/compiler/glsl/glcpp/glcpp-lex.c")
+-        .file("glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.c")
+-        .file("glsl-optimizer/src/compiler/glsl/glcpp/pp_standalone_scaffolding.c")
+-        .file("glsl-optimizer/src/compiler/glsl/glcpp/pp.c")
+-        .file("glsl-optimizer/src/util/blob.c")
+-        .file("glsl-optimizer/src/util/half_float.c")
+-        .file("glsl-optimizer/src/util/hash_table.c")
+-        .file("glsl-optimizer/src/util/mesa-sha1.c")
+-        .file("glsl-optimizer/src/util/ralloc.c")
+-        .file("glsl-optimizer/src/util/set.c")
+-        .file("glsl-optimizer/src/util/sha1/sha1.c")
+-        .file("glsl-optimizer/src/util/softfloat.c")
+-        .file("glsl-optimizer/src/util/string_buffer.c")
+-        .file("glsl-optimizer/src/util/strtod.c")
+-        .compile("glcpp");
+-
+-    configure(&mut cc::Build::new())
+-        .warnings(false)
+-        .include("glsl-optimizer/include")
+-        .include("glsl-optimizer/src/mesa")
+-        .include("glsl-optimizer/src/mapi")
+-        .include("glsl-optimizer/src/compiler")
+-        .include("glsl-optimizer/src/compiler/glsl")
+-        .include("glsl-optimizer/src/gallium/auxiliary")
+-        .include("glsl-optimizer/src/gallium/include")
+-        .include("glsl-optimizer/src")
+-        .include("glsl-optimizer/src/util")
+-        .file("glsl-optimizer/src/mesa/program/dummy_errors.c")
+-        .file("glsl-optimizer/src/mesa/program/symbol_table.c")
+-        .file("glsl-optimizer/src/mesa/main/extensions_table.c")
+-        .file("glsl-optimizer/src/mesa/main/imports.c")
+-        .file("glsl-optimizer/src/compiler/shader_enums.c")
+-        .compile("mesa");
+-
+-    configure(&mut cc::Build::new())
+-        .cpp(true)
+-        .warnings(false)
+-        .include("glsl-optimizer/include")
+-        .include("glsl-optimizer/src/mesa")
+-        .include("glsl-optimizer/src/mapi")
+-        .include("glsl-optimizer/src/compiler")
+-        .include("glsl-optimizer/src/compiler/glsl")
+-        .include("glsl-optimizer/src/gallium/auxiliary")
+-        .include("glsl-optimizer/src/gallium/include")
+-        .include("glsl-optimizer/src")
+-        .include("glsl-optimizer/src/util")
+-        .file("glsl-optimizer/src/compiler/glsl_types.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ast_array_index.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ast_expr.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ast_function.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ast_to_hir.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ast_type.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/builtin_functions.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/builtin_types.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/builtin_variables.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/generate_ir.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/glsl_lexer.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/glsl_optimizer.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/glsl_parser_extras.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/glsl_parser.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/glsl_symbol_table.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/hir_field_selection.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_array_refcount.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_basic_block.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_builder.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_clone.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_constant_expression.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_equals.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_expression_flattening.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_function_can_inline.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_function_detect_recursion.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_function.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_hierarchical_visitor.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_hv_accept.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_print_glsl_visitor.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_print_visitor.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_reader.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_rvalue_visitor.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_set_program_inouts.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_unused_structs.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_validate.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir_variable_refcount.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/ir.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/link_atomics.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/link_functions.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/link_interface_blocks.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/link_uniform_block_active_visitor.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/link_uniform_blocks.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/link_uniform_initializers.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/link_uniforms.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/link_varyings.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/linker_util.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/linker.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/loop_analysis.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/loop_unroll.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_blend_equation_advanced.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_buffer_access.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_const_arrays_to_uniforms.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_cs_derived.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_discard_flow.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_discard.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_distance.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_if_to_cond_assign.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_instructions.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_int64.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_jumps.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_mat_op_to_vec.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_named_interface_blocks.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_noise.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_offset_array.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_output_reads.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_packed_varyings.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_packing_builtins.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_shared_reference.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_subroutine.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_tess_level.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_texture_projection.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_ubo_reference.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_variable_index_to_cond_assign.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_vec_index_to_cond_assign.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_vec_index_to_swizzle.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_vector_derefs.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_vector_insert.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_vector.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/lower_vertex_id.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_algebraic.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_array_splitting.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_conditional_discard.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_constant_folding.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_constant_propagation.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_constant_variable.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_copy_propagation_elements.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_dead_builtin_variables.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_dead_builtin_varyings.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_dead_code_local.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_dead_code.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_dead_functions.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_flatten_nested_if_blocks.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_flip_matrices.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_function_inlining.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_if_simplification.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_minmax.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_rebalance_tree.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_redundant_jumps.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_structure_splitting.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_swizzle.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_tree_grafting.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/opt_vectorize.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/propagate_invariance.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/s_expression.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/serialize.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/shader_cache.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/standalone_scaffolding.cpp")
+-        .file("glsl-optimizer/src/compiler/glsl/string_to_uint_map.cpp")
+-        .compile("glsl_optimizer");
++    // Comment out to control the override behaviour
++    let override_compiler = is_486_target() && !is_486_sb2();
++    //let override_compiler = false
++    //let override_compiler = true;
++
++    if !override_compiler {
++        configure(&mut cc::Build::new())
++            .warnings(false)
++            .include("glsl-optimizer/include")
++            .include("glsl-optimizer/src/mesa")
++            .include("glsl-optimizer/src/mapi")
++            .include("glsl-optimizer/src/compiler")
++            .include("glsl-optimizer/src/compiler/glsl")
++            .include("glsl-optimizer/src/gallium/auxiliary")
++            .include("glsl-optimizer/src/gallium/include")
++            .include("glsl-optimizer/src")
++            .include("glsl-optimizer/src/util")
++            .file("glsl-optimizer/src/compiler/glsl/glcpp/glcpp-lex.c")
++            .file("glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.c")
++            .file("glsl-optimizer/src/compiler/glsl/glcpp/pp_standalone_scaffolding.c")
++            .file("glsl-optimizer/src/compiler/glsl/glcpp/pp.c")
++            .file("glsl-optimizer/src/util/blob.c")
++            .file("glsl-optimizer/src/util/half_float.c")
++            .file("glsl-optimizer/src/util/hash_table.c")
++            .file("glsl-optimizer/src/util/mesa-sha1.c")
++            .file("glsl-optimizer/src/util/ralloc.c")
++            .file("glsl-optimizer/src/util/set.c")
++            .file("glsl-optimizer/src/util/sha1/sha1.c")
++            .file("glsl-optimizer/src/util/softfloat.c")
++            .file("glsl-optimizer/src/util/string_buffer.c")
++            .file("glsl-optimizer/src/util/strtod.c")
++            .compile("glcpp");
++
++        configure(&mut cc::Build::new())
++            .warnings(false)
++            .include("glsl-optimizer/include")
++            .include("glsl-optimizer/src/mesa")
++            .include("glsl-optimizer/src/mapi")
++            .include("glsl-optimizer/src/compiler")
++            .include("glsl-optimizer/src/compiler/glsl")
++            .include("glsl-optimizer/src/gallium/auxiliary")
++            .include("glsl-optimizer/src/gallium/include")
++            .include("glsl-optimizer/src")
++            .include("glsl-optimizer/src/util")
++            .file("glsl-optimizer/src/mesa/program/dummy_errors.c")
++            .file("glsl-optimizer/src/mesa/program/symbol_table.c")
++            .file("glsl-optimizer/src/mesa/main/extensions_table.c")
++            .file("glsl-optimizer/src/mesa/main/imports.c")
++            .file("glsl-optimizer/src/compiler/shader_enums.c")
++            .compile("mesa");
++
++        configure(&mut cc::Build::new())
++            .cpp(true)
++            .warnings(false)
++            .include("glsl-optimizer/include")
++            .include("glsl-optimizer/src/mesa")
++            .include("glsl-optimizer/src/mapi")
++            .include("glsl-optimizer/src/compiler")
++            .include("glsl-optimizer/src/compiler/glsl")
++            .include("glsl-optimizer/src/gallium/auxiliary")
++            .include("glsl-optimizer/src/gallium/include")
++            .include("glsl-optimizer/src")
++            .include("glsl-optimizer/src/util")
++            .file("glsl-optimizer/src/compiler/glsl_types.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ast_array_index.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ast_expr.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ast_function.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ast_to_hir.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ast_type.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/builtin_functions.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/builtin_types.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/builtin_variables.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/generate_ir.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/glsl_lexer.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/glsl_optimizer.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/glsl_parser_extras.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/glsl_parser.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/glsl_symbol_table.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/hir_field_selection.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_array_refcount.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_basic_block.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_builder.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_clone.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_constant_expression.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_equals.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_expression_flattening.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_function_can_inline.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_function_detect_recursion.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_function.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_hierarchical_visitor.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_hv_accept.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_print_glsl_visitor.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_print_visitor.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_reader.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_rvalue_visitor.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_set_program_inouts.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_unused_structs.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_validate.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir_variable_refcount.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/ir.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/link_atomics.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/link_functions.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/link_interface_blocks.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/link_uniform_block_active_visitor.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/link_uniform_blocks.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/link_uniform_initializers.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/link_uniforms.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/link_varyings.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/linker_util.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/linker.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/loop_analysis.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/loop_unroll.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_blend_equation_advanced.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_buffer_access.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_const_arrays_to_uniforms.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_cs_derived.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_discard_flow.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_discard.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_distance.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_if_to_cond_assign.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_instructions.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_int64.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_jumps.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_mat_op_to_vec.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_named_interface_blocks.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_noise.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_offset_array.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_output_reads.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_packed_varyings.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_packing_builtins.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_shared_reference.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_subroutine.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_tess_level.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_texture_projection.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_ubo_reference.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_variable_index_to_cond_assign.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_vec_index_to_cond_assign.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_vec_index_to_swizzle.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_vector_derefs.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_vector_insert.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_vector.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/lower_vertex_id.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_algebraic.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_array_splitting.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_conditional_discard.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_constant_folding.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_constant_propagation.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_constant_variable.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_copy_propagation_elements.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_dead_builtin_variables.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_dead_builtin_varyings.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_dead_code_local.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_dead_code.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_dead_functions.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_flatten_nested_if_blocks.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_flip_matrices.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_function_inlining.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_if_simplification.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_minmax.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_rebalance_tree.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_redundant_jumps.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_structure_splitting.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_swizzle.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_tree_grafting.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/opt_vectorize.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/propagate_invariance.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/s_expression.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/serialize.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/shader_cache.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/standalone_scaffolding.cpp")
++            .file("glsl-optimizer/src/compiler/glsl/string_to_uint_map.cpp")
++            .compile("glsl_optimizer");
++    }
++    else {
++        build("host-cc",
++        &[
++            "glsl-optimizer/include",
++            "glsl-optimizer/src/mesa",
++            "glsl-optimizer/src/mapi",
++            "glsl-optimizer/src/compiler",
++            "glsl-optimizer/src/compiler/glsl",
++            "glsl-optimizer/src/gallium/auxiliary",
++            "glsl-optimizer/src/gallium/include",
++            "glsl-optimizer/src",
++            "glsl-optimizer/src/util"
++        ],
++        &[
++            "glsl-optimizer/src/compiler/glsl/glcpp/glcpp-lex.c",
++            "glsl-optimizer/src/compiler/glsl/glcpp/glcpp-parse.c",
++            "glsl-optimizer/src/compiler/glsl/glcpp/pp_standalone_scaffolding.c",
++            "glsl-optimizer/src/compiler/glsl/glcpp/pp.c",
++            "glsl-optimizer/src/util/blob.c",
++            "glsl-optimizer/src/util/half_float.c",
++            "glsl-optimizer/src/util/hash_table.c",
++            "glsl-optimizer/src/util/mesa-sha1.c",
++            "glsl-optimizer/src/util/ralloc.c",
++            "glsl-optimizer/src/util/set.c",
++            "glsl-optimizer/src/util/sha1/sha1.c",
++            "glsl-optimizer/src/util/softfloat.c",
++            "glsl-optimizer/src/util/string_buffer.c",
++            "glsl-optimizer/src/util/strtod.c"
++        ],
++        "glcpp");
++
++        build("host-cc",
++        &[
++            "glsl-optimizer/include",
++            "glsl-optimizer/src/mesa",
++            "glsl-optimizer/src/mapi",
++            "glsl-optimizer/src/compiler",
++            "glsl-optimizer/src/compiler/glsl",
++            "glsl-optimizer/src/gallium/auxiliary",
++            "glsl-optimizer/src/gallium/include",
++            "glsl-optimizer/src",
++            "glsl-optimizer/src/util"
++        ],
++        &[
++            "glsl-optimizer/src/mesa/program/dummy_errors.c",
++            "glsl-optimizer/src/mesa/program/symbol_table.c",
++            "glsl-optimizer/src/mesa/main/extensions_table.c",
++            "glsl-optimizer/src/mesa/main/imports.c",
++            "glsl-optimizer/src/compiler/shader_enums.c"
++        ],
++        "mesa");
++
++        build("host-c++",
++        &[
++            "glsl-optimizer/include",
++            "glsl-optimizer/src/mesa",
++            "glsl-optimizer/src/mapi",
++            "glsl-optimizer/src/compiler",
++            "glsl-optimizer/src/compiler/glsl",
++            "glsl-optimizer/src/gallium/auxiliary",
++            "glsl-optimizer/src/gallium/include",
++            "glsl-optimizer/src",
++            "glsl-optimizer/src/util"
++        ],
++        &[
++            "glsl-optimizer/src/compiler/glsl_types.cpp",
++            "glsl-optimizer/src/compiler/glsl/ast_array_index.cpp",
++            "glsl-optimizer/src/compiler/glsl/ast_expr.cpp",
++            "glsl-optimizer/src/compiler/glsl/ast_function.cpp",
++            "glsl-optimizer/src/compiler/glsl/ast_to_hir.cpp",
++            "glsl-optimizer/src/compiler/glsl/ast_type.cpp",
++            "glsl-optimizer/src/compiler/glsl/builtin_functions.cpp",
++            "glsl-optimizer/src/compiler/glsl/builtin_types.cpp",
++            "glsl-optimizer/src/compiler/glsl/builtin_variables.cpp",
++            "glsl-optimizer/src/compiler/glsl/generate_ir.cpp",
++            "glsl-optimizer/src/compiler/glsl/glsl_lexer.cpp",
++            "glsl-optimizer/src/compiler/glsl/glsl_optimizer.cpp",
++            "glsl-optimizer/src/compiler/glsl/glsl_parser_extras.cpp",
++            "glsl-optimizer/src/compiler/glsl/glsl_parser.cpp",
++            "glsl-optimizer/src/compiler/glsl/glsl_symbol_table.cpp",
++            "glsl-optimizer/src/compiler/glsl/hir_field_selection.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_array_refcount.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_basic_block.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_builder.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_clone.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_constant_expression.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_equals.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_expression_flattening.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_function_can_inline.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_function_detect_recursion.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_function.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_hierarchical_visitor.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_hv_accept.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_print_glsl_visitor.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_print_visitor.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_reader.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_rvalue_visitor.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_set_program_inouts.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_unused_structs.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_validate.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir_variable_refcount.cpp",
++            "glsl-optimizer/src/compiler/glsl/ir.cpp",
++            "glsl-optimizer/src/compiler/glsl/link_atomics.cpp",
++            "glsl-optimizer/src/compiler/glsl/link_functions.cpp",
++            "glsl-optimizer/src/compiler/glsl/link_interface_blocks.cpp",
++            "glsl-optimizer/src/compiler/glsl/link_uniform_block_active_visitor.cpp",
++            "glsl-optimizer/src/compiler/glsl/link_uniform_blocks.cpp",
++            "glsl-optimizer/src/compiler/glsl/link_uniform_initializers.cpp",
++            "glsl-optimizer/src/compiler/glsl/link_uniforms.cpp",
++            "glsl-optimizer/src/compiler/glsl/link_varyings.cpp",
++            "glsl-optimizer/src/compiler/glsl/linker_util.cpp",
++            "glsl-optimizer/src/compiler/glsl/linker.cpp",
++            "glsl-optimizer/src/compiler/glsl/loop_analysis.cpp",
++            "glsl-optimizer/src/compiler/glsl/loop_unroll.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_blend_equation_advanced.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_buffer_access.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_const_arrays_to_uniforms.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_cs_derived.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_discard_flow.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_discard.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_distance.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_if_to_cond_assign.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_instructions.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_int64.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_jumps.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_mat_op_to_vec.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_named_interface_blocks.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_noise.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_offset_array.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_output_reads.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_packed_varyings.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_packing_builtins.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_shared_reference.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_subroutine.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_tess_level.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_texture_projection.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_ubo_reference.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_variable_index_to_cond_assign.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_vec_index_to_cond_assign.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_vec_index_to_swizzle.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_vector_derefs.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_vector_insert.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_vector.cpp",
++            "glsl-optimizer/src/compiler/glsl/lower_vertex_id.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_algebraic.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_array_splitting.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_conditional_discard.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_constant_folding.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_constant_propagation.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_constant_variable.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_copy_propagation_elements.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_dead_builtin_variables.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_dead_builtin_varyings.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_dead_code_local.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_dead_code.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_dead_functions.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_flatten_nested_if_blocks.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_flip_matrices.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_function_inlining.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_if_simplification.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_minmax.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_rebalance_tree.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_redundant_jumps.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_structure_splitting.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_swizzle.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_tree_grafting.cpp",
++            "glsl-optimizer/src/compiler/glsl/opt_vectorize.cpp",
++            "glsl-optimizer/src/compiler/glsl/propagate_invariance.cpp",
++            "glsl-optimizer/src/compiler/glsl/s_expression.cpp",
++            "glsl-optimizer/src/compiler/glsl/serialize.cpp",
++            "glsl-optimizer/src/compiler/glsl/shader_cache.cpp",
++            "glsl-optimizer/src/compiler/glsl/standalone_scaffolding.cpp",
++            "glsl-optimizer/src/compiler/glsl/string_to_uint_map.cpp"
++        ],
++        "glsl_optimizer");
++
++        println!("cargo:rustc-link-lib=stdc++");
++    }
+ }
+-- 
+2.17.1
+

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -304,6 +304,11 @@ echo "ac_add_options --target=armv7-unknown-linux-gnueabihf" >> "$MOZCONFIG"
 # hack for when not using virtualenv
 ln -sf "%BUILD_DIR"/config.status $PWD/build/config.status
 
+# hack to circumvent std include_next bug JB#55058
+%ifarch %arm
+if [ ! -L "%BUILD_DIR"/include ] ; then ln -s /usr/include/c++/8.3.0/ "%BUILD_DIR"/include; fi
+%endif
+
 # %ifarch %arm
 # Do not build as thumb since it breaks video decoding.
 # echo "ac_add_options --with-thumb=no" >> "$MOZCONFIG"

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -260,6 +260,7 @@ echo "export RUST_HOST_TARGET=%SB2_TARGET" >> "%BUILD_DIR"/rpm-shared.env
 echo "export RUST_TARGET=%SB2_TARGET" >> "%BUILD_DIR"/rpm-shared.env
 echo "export TARGET=%SB2_TARGET" >> "%BUILD_DIR"/rpm-shared.env
 echo "export HOST=%SB2_TARGET" >> "%BUILD_DIR"/rpm-shared.env
+echo "export SB2_TARGET=%SB2_TARGET" >> "%BUILD_DIR"/rpm-shared.env
 
 %ifarch %arm
 # See config/makefiles/rust.mk

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -80,6 +80,7 @@ Patch33:    0033-Get-target-and-host-from-environment.patch
 Patch34:    0034-sailfishos-gecko-Disable-link-time-optimization-for-.patch
 Patch35:    0035-sailfishos-gecko-Patch-libloading-to-build-on-arm.-J.patch
 Patch36:    0036-sailfishos-gecko-Skip-min_libclang_version-test-duri.patch
+Patch37:    0037-sailfishos-gecko-Patch-glslopt-to-build-on-arm.patch
 #Patch9:     0009-sailfishos-gecko-Create-EmbedLiteCompositorBridgePar.patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -77,6 +77,7 @@ Patch30:    0030-sailfishos-configure-Read-rustc-host-from-environmen.patch
 Patch31:    0031-sailfishos-configure-Drop-thumbv7neon-and-thumbv7a-p.patch
 Patch32:    0032-Hacking-rust.mk.patch
 Patch33:    0033-Get-target-and-host-from-environment.patch
+Patch34:    0034-sailfishos-gecko-Disable-link-time-optimization-for-.patch
 #Patch9:     0009-sailfishos-gecko-Create-EmbedLiteCompositorBridgePar.patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -78,6 +78,7 @@ Patch31:    0031-sailfishos-configure-Drop-thumbv7neon-and-thumbv7a-p.patch
 Patch32:    0032-Hacking-rust.mk.patch
 Patch33:    0033-Get-target-and-host-from-environment.patch
 Patch34:    0034-sailfishos-gecko-Disable-link-time-optimization-for-.patch
+Patch35:    0035-sailfishos-gecko-Patch-libloading-to-build-on-arm.-J.patch
 #Patch9:     0009-sailfishos-gecko-Create-EmbedLiteCompositorBridgePar.patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -378,7 +378,7 @@ echo "ac_add_options --disable-elf-hack" >> "$MOZCONFIG"
 # but as sailfish-browser has privileged EGID, glibc removes it for security reasons. 
 # Set ELF RPATH through LDFLAGS. Needed for plugin-container and libxul.so
 # Additionally we limit the memory usage during linking
- echo 'FIX_LDFLAGS="-Wl,--reduce-memory-overheads -Wl,--no-keep-memory -Wl,-rpath=%{mozappdir}"' >> "${MOZCONFIG}"
+ echo 'FIX_LDFLAGS="-Wl,--strip-debug -Wl,--gc-sections -Wl,--reduce-memory-overheads -Wl,--no-keep-memory -Wl,-rpath=%{mozappdir}"' >> "${MOZCONFIG}"
  echo 'export LDFLAGS="$FIX_LDFLAGS"' >> "${MOZCONFIG}"
  echo 'LDFLAGS="$FIX_LDFLAGS"' >> "${MOZCONFIG}"
  echo 'export WRAP_LDFLAGS="$FIX_LDFLAGS"' >> "${MOZCONFIG}"

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -305,9 +305,13 @@ echo "ac_add_options --target=armv7-unknown-linux-gnueabihf" >> "$MOZCONFIG"
 # hack for when not using virtualenv
 ln -sf "%BUILD_DIR"/config.status $PWD/build/config.status
 
-# hack to circumvent std include_next bug JB#55058
 %ifarch %arm
+# Make stdc++ headers avaiilable on a fresh path to work around include_next bug JB#55058
 if [ ! -L "%BUILD_DIR"/include ] ; then ln -s /usr/include/c++/8.3.0/ "%BUILD_DIR"/include; fi
+# Expose the elf32-i386 libclang.so.10 for use inside the arm target, JB#55042
+mkdir -p "%BUILD_DIR"/lib
+SBOX_DISABLE_MAPPING=1 cp /usr/lib/libclang.so.10 "%BUILD_DIR"/lib/libclang.so.10
+echo "ac_add_options --with-libclang-path='"%BUILD_DIR"/lib/'" >> "$MOZCONFIG"
 %endif
 
 # %ifarch %arm

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -79,6 +79,7 @@ Patch32:    0032-Hacking-rust.mk.patch
 Patch33:    0033-Get-target-and-host-from-environment.patch
 Patch34:    0034-sailfishos-gecko-Disable-link-time-optimization-for-.patch
 Patch35:    0035-sailfishos-gecko-Patch-libloading-to-build-on-arm.-J.patch
+Patch36:    0036-sailfishos-gecko-Skip-min_libclang_version-test-duri.patch
 #Patch9:     0009-sailfishos-gecko-Create-EmbedLiteCompositorBridgePar.patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch


### PR DESCRIPTION
libloading mixes both rust and C code. When build on for an arm target
using sb2 the C code in global_static.c ends up in elf32-littleendian
format, whereas it should be elf32-i486.

This patch overrides the default build step using cc::Build to force the
right tool to be used (host-gcc) and allow libloading to be compiled and
linked against.