### PR TITLE
Initialize profiler properly

### DIFF
--- a/embedding/embedlite/EmbedLiteApp.cpp
+++ b/embedding/embedlite/EmbedLiteApp.cpp
@@ -32,8 +32,6 @@
 #include "EmbedLiteCompositorBridgeParent.h"
 #include "EmbedLiteAppProcessParent.h"
 
-#include "GeckoProfiler.h"
-
 namespace mozilla {
 namespace startup {
 extern bool sIsEmbedlite;
@@ -165,9 +163,6 @@ EmbedLiteApp::StartChild(EmbedLiteApp* aApp)
   LOGT();
   NS_ASSERTION(aApp->mState == STARTING, "Wrong timing");
   if (aApp->mEmbedType == EMBED_THREAD) {
-    char aLocal;
-    profiler_init(&aLocal);
-
     if (!aApp->mListener ||
         !aApp->mListener->ExecuteChildThread()) {
       // If toolkit hasn't started a child thread we have to create the thread on our own
@@ -289,7 +284,6 @@ EmbedLiteApp::StopChildThread()
 {
   NS_ENSURE_TRUE(mEmbedType == EMBED_THREAD, false);
   LOGT("mUILoop:%p, current:%p", mUILoop, MessageLoop::current());
-  profiler_shutdown();
 
   if (!mUILoop || !MessageLoop::current() ||
       mUILoop == MessageLoop::current()) {

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -227,7 +227,7 @@ EmbedLiteViewChild::InitGeckoWindow(const uint32_t parentId, const bool isPrivat
   mChrome = new WebBrowserChrome(this);
 
   // FIXME - aBrowsingContext and aInitialWindowChild are not passed.
-  // Task to analyze/fix: 54382
+  // Task to analyze/fix: JB#54382
   mWebBrowser = nsWebBrowser::Create(mChrome, mWidget, nullptr,
                                      nullptr);
   mWebBrowser->SetAllowDNSPrefetch(true);

--- a/embedding/embedlite/utils/GeckoLoader.cpp
+++ b/embedding/embedlite/utils/GeckoLoader.cpp
@@ -248,8 +248,6 @@ GeckoLoader::InitEmbedding(const char* aProfilePath)
     XRE_NotifyProfile();
   }
 
-  NS_LogTerm();
-
   LOGF("InitEmbedding successfully");
   return true;
 }
@@ -262,9 +260,6 @@ GeckoLoader::TermEmbedding()
     return false;
   }
   sInitialized = false;
-
-  // Get rid of the bogus TLS warnings
-  NS_LogInit();
 
   // make sure this is freed before shutting down xpcom
   NS_IF_RELEASE(kDirectoryProvider.sProfileLock);

--- a/embedding/embedlite/utils/GeckoLoader.cpp
+++ b/embedding/embedlite/utils/GeckoLoader.cpp
@@ -125,10 +125,10 @@ GeckoLoader::InitEmbedding(const char* aProfilePath)
 #endif
 
   const char* greHome = getenv("GRE_HOME");
-    if (!greHome) {
-      LOGE("GRE_HOME is not defined\n");
-      return false;
-    }
+  if (!greHome) {
+    LOGE("GRE_HOME is not defined\n");
+    return false;
+  }
 
   nsCOMPtr<nsIFile> xuldir;
   rv = XRE_GetFileFromPath(greHome, getter_AddRefs(xuldir));


### PR DESCRIPTION
This PR contains two main fixes. In addition, there are two small cleanup commits.

The first commit fixes initialization sequence. It should be following and there should
be reverse order in the TermEmbedding.

- NS_LogInit - sets main thread
- IOInterposer::Init
- profiler_init

GeckoProfiler.h states that profiler_init call must happen before any
other profiler calls.

The second commit removes wrong NS_LogTerm call as we do not have
"event loop" per se rather the constructed worker thread is our gecko main thread. Hence,
NS_LogTerm call should be only called from the TermEmbedding.