### PR TITLE
[sailfishos][gecko] Bring back: 'Avoid incorrect compiler optimisation' patch. JB#55228 OMP#JOLLA-298

### DIFF
--- a/rpm/0042-sailfishos-gecko-Avoid-incorrect-compiler-optimisati.patch
+++ b/rpm/0042-sailfishos-gecko-Avoid-incorrect-compiler-optimisati.patch
@@ -36,10 +36,10 @@ Signed-off-by: David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/js/src/old-configure.in b/js/src/old-configure.in
-index 3d53ee1c3c81..286643091d8c 100644
+index 29d32873112c..e5a75ab568ad 100644
 --- a/js/src/old-configure.in
 +++ b/js/src/old-configure.in
-@@ -620,7 +620,7 @@ case "$target" in
+@@ -483,7 +483,7 @@ case "$target" in
  *-*linux*)
      if test "$GNU_CC" -o "$GNU_CXX"; then
          MOZ_PGO_OPTIMIZE_FLAGS="-O3"
@@ -49,18 +49,18 @@ index 3d53ee1c3c81..286643091d8c 100644
             MOZ_OPTIMIZE_FLAGS="-freorder-blocks $MOZ_OPTIMIZE_FLAGS"
          fi
 diff --git a/js/src/vm/ProxyObject.cpp b/js/src/vm/ProxyObject.cpp
-index 13b52fd6077f..c6166ad61f43 100644
+index 2b29dcdf8f8d..6964a24e200f 100644
 --- a/js/src/vm/ProxyObject.cpp
 +++ b/js/src/vm/ProxyObject.cpp
-@@ -78,7 +78,7 @@ static gc::AllocKind GetProxyGCObjectKind(const Class* clasp,
-     MOZ_ASSERT(priv.isNull() ||
-                (priv.isGCThing() && priv.toGCThing()->isTenured()));
-     newKind = SingletonObject;
--  } else if ((priv.isGCThing() && priv.toGCThing()->isTenured()) ||
-+  } else if ((priv.isGCThing() && priv.toGCThing() && priv.toGCThing()->isTenured()) ||
-              !handler->canNurseryAllocate()) {
-     newKind = TenuredObject;
-   }
+@@ -131,7 +131,7 @@ ProxyObject* ProxyObject::New(JSContext* cx, const BaseProxyHandler* handler,
+   {
+     AutoSweepObjectGroup sweep(group);
+     if (group->shouldPreTenure(sweep) ||
+-        (priv.isGCThing() && priv.toGCThing()->isTenured()) ||
++        (priv.isGCThing() && priv.toGCThing() && priv.toGCThing()->isTenured()) ||
+         !handler->canNurseryAllocate()) {
+       heap = gc::TenuredHeap;
+     } else {
 -- 
-2.26.2
+2.31.1
 

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -87,6 +87,7 @@ Patch38:    0038-sailfishos-configure-Patch-glslopt-to-build-on-arm.patch
 Patch39:    0039-sailfishos-embedlite-egl-Fix-mesa-egl-display-initia.patch
 Patch40:    0040-sailfishos-egl-Do-not-create-CreateFallbackSurface.-.patch
 Patch41:    0041-sailfishos-gecko-Fix-gfxPlatform-AsyncPanZoomEnabled.patch
+Patch42:    0042-sailfishos-gecko-Avoid-incorrect-compiler-optimisati.patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch
 #Patch12:    0012-sailfishos-build-Fix-build-error-with-newer-glibc.patch
@@ -100,7 +101,6 @@ Patch41:    0041-sailfishos-gecko-Fix-gfxPlatform-AsyncPanZoomEnabled.patch
 #Patch24:    0024-sailfishos-gecko-Use-libcontentaction-for-custom-sch.patch
 #Patch25:    0025-sailfishos-gecko-Handle-temporary-directory-similarl.patch
 #Patch26:    0026-sailfishos-gecko-Disable-loading-heavier-extensions.patch
-#Patch27:    0027-sailfishos-gecko-Avoid-incorrect-compiler-optimisati.patch
 #Patch28:    0028-sailfishos-gecko-Avoid-rogue-origin-points-when-clip.patch
 #Patch29:    0029-sailfishos-gecko-Allow-render-shaders-to-be-loaded-f.patch
 #Patch30:    0030-sailfishos-gecko-Prioritize-GMP-plugins-over-all-oth.patch


### PR DESCRIPTION
Whilst doing https://github.com/sailfishos/gecko-dev/pull/37 got one gcc crash and thought that is could have been caused by this but in reality was caused by my own change. As I already had this one backported decided to open this PR as well.