### PR TITLE
[sailfishos][gecko] Force MOZ_BUILD_DATE env var in order to have more reproducible builds JB#55269 OMP#JOLLA-305

### DIFF
--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -320,6 +320,17 @@ echo "export CARGO_NET_OFFLINE=1" >> "%BUILD_DIR"/rpm-shared.env
 echo "export CARGO_BUILD_TARGET=armv7-unknown-linux-gnueabihf" >> "%BUILD_DIR"/rpm-shared.env
 echo "export CARGO_CFG_TARGET_ARCH=arm" >> "%BUILD_DIR"/rpm-shared.env
 
+# Force MOZ_BUILD_DATE env var in order to have more reproducible builds
+# only when we're building from tarball (OBS)
+# If you want to have a fixed date, then uncomment the line below
+# echo "export MOZ_BUILD_DATE=20210831010100" >> "%BUILD_DIR"/rpm-shared.env
+for a in %{_sourcedir}/*.tar.bz2; do
+    TARBALL_DATE=`stat -c %Y $a`
+    BUILD_DATE=`date -d @${TARBALL_DATE} +"%Y%m%d%H%M%%S"`
+    echo "export MOZ_BUILD_DATE=${BUILD_DATE}" >> "%BUILD_DIR"/rpm-shared.env
+    break
+done
+
 %build
 
 source "%BUILD_DIR"/rpm-shared.env


### PR DESCRIPTION
This uses the date of the tarball (only used when tarball is created from tar_git, so only for OBS). As rebuilds only differ based on this timestamp in the .so files, this now makes them reproducible.

OBS will now report for example:
Retried build at Fri Sep  3 07:15:02 2021 returned same result, skipped