### PR TITLE
Adapt EmbedLiteViewChild::RecvHandleSingleTap

### DIFF
--- a/embedding/embedlite/embedthread/EmbedContentController.h
+++ b/embedding/embedlite/embedthread/EmbedContentController.h
@@ -71,10 +71,12 @@ private:
   void HandleSingleTap(const LayoutDevicePoint aPoint, Modifiers aModifiers, const ScrollableLayerGuid aGuid, uint64_t aInputBlockId);
   void HandleLongTap(const LayoutDevicePoint aPoint, Modifiers aModifiers, const ScrollableLayerGuid aGuid, uint64_t aInputBlockId);
 
+  void DoRequestContentRepaint(const layers::RepaintRequest aRequest);
   void DoSendScrollEvent(const layers::RepaintRequest aRequest);
 
   nsIntPoint convertIntPoint(const LayoutDevicePoint &aPoint);
 
+  MessageLoop* mUILoop;
   nsISerialEventTarget *mUIThread;
   EmbedLiteViewParent* mRenderFrame;
 };


### PR DESCRIPTION
PR contains two commits

1) Use APZEventState::ProcessSingleTap in EmbedLiteViewChild::RecvHandleSingleTap

2) Use MessageLoop to forward events

The current nsThread passed by the EmbedLiteViewParent does not
have event queue initialized i.e. it was initialized with nsThread()
constructor. This initialization step looks to be coming via
nsThreadManager::GetCurrentThread.

The MessageLoop has nsISerialEventTarget in place. Thus, it can be
used to forward events as we did in past.

This commit effectively reverts sha1 c5d20afd1dc6cee148d6f6b2a10f371558f72ef6
