### PR TITLE
[sailfishos][embedlite] Fix search plugin directories. JB#55267 OMP#JOLLA-304

### DIFF
--- a/embedding/embedlite/utils/DirProvider.cpp
+++ b/embedding/embedlite/utils/DirProvider.cpp
@@ -9,7 +9,10 @@
 #include "nsAppDirectoryServiceDefs.h"
 #include "nsDirectoryServiceDefs.h"
 #include "nsXULAppAPI.h"
+#include "nsSimpleEnumerator.h"
 
+#define NS_SYSTEM_SEARCH_DIR_KEY "SystemSearchDir"
+#define NS_USER_SEARCH_DIR_KEY "UserSearchDir"
 
 nsIDirectoryServiceProvider* DirProvider::sAppFileLocProvider = nullptr;
 nsCOMPtr<nsIFile> DirProvider::sProfileDir = nullptr;
@@ -36,6 +39,30 @@ NS_IMETHODIMP
 DirProvider::GetFile(const char* aKey, bool* aPersist,
                      nsIFile* *aResult)
 {
+  if (!strcmp(aKey, NS_SYSTEM_SEARCH_DIR_KEY)) {
+    nsCOMPtr<nsIFile> file;
+    nsresult rv;
+#if defined(HAVE_USR_LIB64_DIR) && defined(__LP64__)
+    rv = NS_NewNativeLocalFile(nsDependentCString("/usr/lib64/mozembedlite/chrome/embedlite/content"), false, getter_AddRefs(file));
+#else
+    rv = NS_NewNativeLocalFile(nsDependentCString("/usr/lib/mozembedlite/chrome/embedlite/content"), false, getter_AddRefs(file));
+#endif
+    if (file && NS_SUCCEEDED(rv))
+      file.forget(aResult);
+    return rv;
+  }
+
+  if (!strcmp(aKey, NS_USER_SEARCH_DIR_KEY)) {
+    nsCOMPtr<nsIFile> file;
+    nsresult rv = NS_NewNativeLocalFile(nsDependentCString(PR_GetEnv("HOME")), true, getter_AddRefs(file));
+    if (NS_SUCCEEDED(rv)) {
+      rv = file->AppendRelativeNativePath(NS_LITERAL_CSTRING(".local/share/org.sailfishos/browser/searchEngines"));
+      if (file && NS_SUCCEEDED(rv))
+        file.forget(aResult);
+    }
+    return rv;
+  }
+
   if (sAppFileLocProvider) {
     nsresult rv = sAppFileLocProvider->GetFile(aKey, aPersist, aResult);
     if (NS_SUCCEEDED(rv)) {
@@ -88,10 +115,67 @@ DirProvider::GetFile(const char* aKey, bool* aPersist,
   return NS_ERROR_NOT_IMPLEMENTED;
 }
 
+// Enumerator copied from nsAppFileLocationProvider.cpp
+class nsAppDirectoryEnumerator : public nsSimpleEnumerator {
+ public:
+  /**
+   * aKeyList is a null-terminated list of properties which are provided by
+   * aProvider They do not need to be publicly defined keys.
+   */
+  nsAppDirectoryEnumerator(nsIDirectoryServiceProvider* aProvider,
+                           const char* aKeyList[])
+      : mProvider(aProvider), mCurrentKey(aKeyList) {}
+
+  const nsID& DefaultInterface() override { return NS_GET_IID(nsIFile); }
+
+  NS_IMETHOD HasMoreElements(bool* aResult) override {
+    while (!mNext && *mCurrentKey) {
+      bool dontCare;
+      nsCOMPtr<nsIFile> testFile;
+      (void)mProvider->GetFile(*mCurrentKey++, &dontCare,
+                               getter_AddRefs(testFile));
+      mNext = testFile;
+    }
+    *aResult = mNext != nullptr;
+    return NS_OK;
+  }
+
+  NS_IMETHOD GetNext(nsISupports** aResult) override {
+    if (NS_WARN_IF(!aResult)) {
+      return NS_ERROR_INVALID_ARG;
+    }
+    *aResult = nullptr;
+
+    bool hasMore;
+    HasMoreElements(&hasMore);
+    if (!hasMore) {
+      return NS_ERROR_FAILURE;
+    }
+
+    *aResult = mNext;
+    NS_IF_ADDREF(*aResult);
+    mNext = nullptr;
+
+    return *aResult ? NS_OK : NS_ERROR_FAILURE;
+  }
+
+ protected:
+  nsCOMPtr<nsIDirectoryServiceProvider> mProvider;
+  const char** mCurrentKey;
+  nsCOMPtr<nsIFile> mNext;
+};
+
 NS_IMETHODIMP
 DirProvider::GetFiles(const char* aKey,
                       nsISimpleEnumerator* *aResult)
 {
+  if (!strcmp(aKey, NS_APP_DISTRIBUTION_SEARCH_DIR_LIST)) {
+    static const char* keys[] = {NS_USER_SEARCH_DIR_KEY, NS_SYSTEM_SEARCH_DIR_KEY, nullptr};
+    *aResult = new nsAppDirectoryEnumerator(this, keys);
+    NS_ADDREF(*aResult);
+    return NS_OK;
+  }
+
   nsCOMPtr<nsIDirectoryServiceProvider2>
   dp2(do_QueryInterface(sAppFileLocProvider));
 


### PR DESCRIPTION
Tried to find a way to do this without a patch but didn't figure out any other way. Also the paths could be more dynamic but couldn't find any way to retrieve them.