### PR TITLE
Fix MessageManagerCallback overrides

### DIFF
--- a/embedding/embedlite/PEmbedLiteView.ipdl
+++ b/embedding/embedlite/PEmbedLiteView.ipdl
@@ -142,9 +142,6 @@ parent:
     sync SyncMessage(nsString aMessage, nsString aJSON)
       returns (nsString[] retval);
 
-    nested(inside_sync) sync RpcMessage(nsString aMessage, nsString aJSON)
-      returns (nsString[] retval);
-
     // IME
     sync GetInputContext() returns (int32_t IMEEnabled, int32_t IMEOpen);
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -470,18 +470,6 @@ EmbedLiteViewChild::DoSendSyncMessage(const char16_t* aMessageName, const char16
   return true;
 }
 
-bool
-EmbedLiteViewChild::DoCallRpcMessage(const char16_t* aMessageName, const char16_t* aMessage, nsTArray<nsString>* aJSONRetVal)
-{
-#if EMBEDLITE_LOG_SENSITIVE
-  LOGT("msg:%s, data:%s", NS_ConvertUTF16toUTF8(aMessageName).get(), NS_ConvertUTF16toUTF8(aMessage).get());
-#endif
-  if (mRegisteredMessages.Get(nsDependentString(aMessageName))) {
-    SendRpcMessage(nsDependentString(aMessageName), nsDependentString(aMessage), aJSONRetVal);
-  }
-  return true;
-}
-
 nsIWebNavigation*
 EmbedLiteViewChild::WebNavigation()
 {

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.h
@@ -73,9 +73,6 @@ public:
   virtual bool DoSendSyncMessage(const char16_t* aMessageName,
                                  const char16_t* aMessage,
                                  nsTArray<nsString>* aJSONRetVal) override;
-  virtual bool DoCallRpcMessage(const char16_t* aMessageName,
-                                const char16_t* aMessage,
-                                nsTArray<nsString>* aJSONRetVal) override;
 
   /**
    * Relay given frame metrics to listeners subscribed via EmbedLiteAppService

--- a/embedding/embedlite/embedshared/EmbedLiteViewChildIface.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChildIface.h
@@ -56,9 +56,6 @@ public:
   virtual bool DoSendSyncMessage(const char16_t* aMessageName,
                                  const char16_t* aMessage,
                                  nsTArray<nsString>* aJSONRetVal) = 0;
-  virtual bool DoCallRpcMessage(const char16_t* aMessageName,
-                                const char16_t* aMessage,
-                                nsTArray<nsString>* aJSONRetVal) = 0;
   virtual bool GetDPI(float* aDPI) = 0;
 
   /**

--- a/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
@@ -320,13 +320,6 @@ mozilla::ipc::IPCResult EmbedLiteViewParent::RecvSyncMessage(const nsString &aMe
   return IPC_OK();
 }
 
-mozilla::ipc::IPCResult EmbedLiteViewParent::RecvRpcMessage(const nsString &aMessage,
-                                                            const nsString &aJSON,
-                                                            nsTArray<nsString> *aJSONRetVal)
-{
-  return RecvSyncMessage(aMessage, aJSON, aJSONRetVal);
-}
-
 mozilla::ipc::IPCResult EmbedLiteViewParent::RecvSetTargetAPZC(const uint64_t &aInputBlockId,
                                                                nsTArray<ScrollableLayerGuid> &&aTargets)
 {

--- a/embedding/embedlite/embedshared/EmbedLiteViewParent.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewParent.h
@@ -73,9 +73,6 @@ protected:
   virtual mozilla::ipc::IPCResult RecvSyncMessage(const nsString &aMessage,
                                                   const nsString &aJSON,
                                                   nsTArray<nsString> *aJSONRetVal);
-  virtual mozilla::ipc::IPCResult RecvRpcMessage(const nsString &aMessage,
-                                                 const nsString &aJSON,
-                                                 nsTArray<nsString> *aJSONRetVal);
 
   virtual mozilla::ipc::IPCResult RecvUpdateZoomConstraints(const uint32_t &aPresShellId,
                                                             const ViewID &aViewId,

--- a/embedding/embedlite/utils/BrowserChildHelper.h
+++ b/embedding/embedlite/utils/BrowserChildHelper.h
@@ -114,19 +114,17 @@ public:
   nsIWebNavigation* WebNavigation() const;
   nsIWidget* WebWidget();
 
-  bool DoLoadMessageManagerScript(const nsAString& aURL, bool aRunInGlobalScope);
-  bool DoSendBlockingMessage(JSContext* aCx,
-                             const nsAString& aMessage,
+
+  /**
+   * MessageManagerCallback methods that we override.
+   */
+  bool DoLoadMessageManagerScript(const nsAString& aURL, bool aRunInGlobalScope) override;
+  bool DoSendBlockingMessage(const nsAString& aMessage,
                              mozilla::dom::ipc::StructuredCloneData& aData,
-                             JS::Handle<JSObject *> aCpows,
-                             nsIPrincipal* aPrincipal,
-                             nsTArray<mozilla::dom::ipc::StructuredCloneData>* aRetVal,
-                             bool aIsSync);
-  nsresult DoSendAsyncMessage(JSContext* aCx,
-                              const nsAString& aMessage,
-                              mozilla::dom::ipc::StructuredCloneData& aData,
-                              JS::Handle<JSObject *> aCpows,
-                              nsIPrincipal* aPrincipal);
+                             nsTArray<mozilla::dom::ipc::StructuredCloneData>* aRetVal) override;
+  nsresult DoSendAsyncMessage(const nsAString& aMessage,
+                              mozilla::dom::ipc::StructuredCloneData& aData) override;
+
   bool DoUpdateZoomConstraints(const uint32_t& aPresShellId,
                                const mozilla::layers::ScrollableLayerGuid::ViewID &aViewId,
                                const Maybe<mozilla::layers::ZoomConstraints>& aConstraints);

--- a/rpm/0003-sailfishos-ipc-Whitelist-sync-messages-of-EmbedLite..patch
+++ b/rpm/0003-sailfishos-ipc-Whitelist-sync-messages-of-EmbedLite..patch
@@ -24,8 +24,6 @@ index 88ad49d169e8..8686db5d9612 100644
 +description = EmbedLite
 +[PEmbedLiteView::SyncMessage]
 +description = EmbedLite
-+[PEmbedLiteView::RpcMessage]
-+description = EmbedLite
 +[PEmbedLiteView::GetInputContext]
 +description = EmbedLite
 +


### PR DESCRIPTION
This PR fixes MessageManagerCallback overrides of the BrowserChildHelper making sendAsyncMessage and sendSyncMessage (MessageManagerGlobal.h) to work. We missed this override as MessageManagerCallback (nsFrameMessageManager.h) is not pure virtual rather having dummy implementations. 

Second commit removes obsolete RpcMessage.