### PR TITLE
Disable startupCache for all architectures. Fixes JB#55487 OMP-JOLLA-373

### DIFF
--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -415,10 +415,12 @@ echo "ac_add_options --host=i686-unknown-linux-gnu" >> "$MOZCONFIG"
 %endif
 
 %ifarch %arm32
+echo "ac_add_options --disable-startupcache" >> "$MOZCONFIG"
 echo "ac_add_options --host=armv7-unknown-linux-gnueabihf" >> "$MOZCONFIG"
 %endif
 
 %ifarch %arm64
+echo "ac_add_options --disable-startupcache" >> "$MOZCONFIG"
 echo "ac_add_options --host=aarch64-unknown-linux-gnu" >> "$MOZCONFIG"
 %endif
 


### PR DESCRIPTION
Running with a startupCache can cause unexpected behaviour when old code
in the cache is used instead of updated code.

This is intended as a temporary change during development.