### PR TITLE
Avoid stripping debug symbols during final link step on arm. JB#55074 OMP#JOLLA-269

### DIFF
--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -433,8 +433,8 @@ echo "ac_add_options --disable-elf-hack" >> "$MOZCONFIG"
 # Set ELF RPATH through LDFLAGS. Needed for plugin-container and libxul.so
 # Additionally we limit the memory usage during linking
 %ifarch %arm32 %arm64
-# Strip debug symbols and garbage collect on arm to link in 32 bit address space, JB#55074
-echo 'FIX_LDFLAGS="-Wl,--strip-debug -Wl,--gc-sections -Wl,--reduce-memory-overheads -Wl,--no-keep-memory -Wl,-rpath=%{mozappdir}"' >> "${MOZCONFIG}"
+# Garbage collect on arm to reduce memory requirements, JB#55074
+echo 'FIX_LDFLAGS="-Wl,--gc-sections -Wl,--reduce-memory-overheads -Wl,--no-keep-memory -Wl,-rpath=%{mozappdir}"' >> "${MOZCONFIG}"
 %else
 echo 'FIX_LDFLAGS="-Wl,--reduce-memory-overheads -Wl,--no-keep-memory -Wl,-rpath=%{mozappdir}"' >> "${MOZCONFIG}"
 %endif


### PR DESCRIPTION
Previously the final link step was failing on arm builds due to
out-of-memory issues (it seemed to run out of address space on the
32-bit SDK).

Something seems to have changed, since it now passes through okay, so
this change makes it so that it no longer strip the debug symbols.