### PR TITLE
[sailfishos][embedlite] Adapt package-manifest.in from Android FF. Fixes JB#55467 OMP#JOLLA-358

### DIFF
--- a/embedding/embedlite/installer/package-manifest.in
+++ b/embedding/embedlite/installer/package-manifest.in
@@ -12,6 +12,9 @@
 ; - in front of a file specifies it to be removed from the destination
 ; * wildcard support to recursively copy the entire directory
 ; ; file comment
+;
+
+#filter substitution
 
 [@AB_CD@]
 @RESPATH@/chrome/@AB_CD@@JAREXT@
@@ -21,306 +24,63 @@
 @BINPATH@/updater.ini
 #endif
 @BINPATH@/dictionaries/*
-#ifdef XP_WIN32
-@BINPATH@/uninstall/helper.exe
+@BINPATH@/hyphenation/*
+@BINPATH@/localization/*
+
+#ifdef MOZ_CLANG_RT_ASAN_LIB
+@BINPATH@/@MOZ_CLANG_RT_ASAN_LIB@
 #endif
 
-[xpcom]
-@RESPATH@/dependentlibs.list
-
-[browser]
-; [Base Browser Files]
-@RESPATH@/platform.ini
+#ifndef MOZ_STATIC_JS
+@BINPATH@/@DLL_PREFIX@mozjs@DLL_SUFFIX@
+#endif
+#ifdef MOZ_DMD
+@BINPATH@/@DLL_PREFIX@dmd@DLL_SUFFIX@
+#endif
 @BINPATH@/@DLL_PREFIX@lgpllibs@DLL_SUFFIX@
 #ifdef MOZ_FFVPX
 @BINPATH@/@DLL_PREFIX@mozavutil@DLL_SUFFIX@
 @BINPATH@/@DLL_PREFIX@mozavcodec@DLL_SUFFIX@
 #endif
 @BINPATH@/@DLL_PREFIX@xul@DLL_SUFFIX@
+
+#ifndef CROSS_COMPILE
+@BINPATH@/@DLL_PREFIX@freebl3.chk
+@BINPATH@/@DLL_PREFIX@softokn3.chk
+#endif
+
+#ifndef MOZ_FOLD_LIBS
+@BINPATH@/@DLL_PREFIX@mozsqlite3@DLL_SUFFIX@
+#endif
+
 # This should be MOZ_CHILD_PROCESS_NAME, but that has a "lib/" prefix.
 @BINPATH@/@MOZ_CHILD_PROCESS_NAME@
 
-[sqlite]
-@BINPATH@/@DLL_PREFIX@mozsqlite3@DLL_SUFFIX@
+[xpcom]
+@RESPATH@/dependentlibs.list
+
+[browser]
+; [Base Browser Files]
+@BINPATH@/application.ini
+@BINPATH@/platform.ini
+@BINPATH@/defaults/settings/blocklists/addons.json
+; TODO bug 1639050: addons-bloomfilters should be used instead of addons.json
+@BINPATH@/defaults/settings/security-state/onecrl.json
 
 ; [Components]
-#ifdef MOZ_ARTIFACT_BUILDS
-@BINPATH@/components/interfaces.xpt
-@BINPATH@/components/prebuilt-interfaces.manifest
-#endif
-@BINPATH@/components/alerts.xpt
-#ifdef ACCESSIBILITY
-@BINPATH@/components/accessibility.xpt
-#endif
-@BINPATH@/components/appshell.xpt
-@BINPATH@/components/appstartup.xpt
-@BINPATH@/components/autocomplete.xpt
-@BINPATH@/components/autoconfig.xpt
-@BINPATH@/components/browser-element.xpt
-@BINPATH@/components/caps.xpt
-@BINPATH@/components/chrome.xpt
-@BINPATH@/components/commandhandler.xpt
-@BINPATH@/components/commandlines.xpt
-@BINPATH@/components/composer.xpt
-@BINPATH@/components/content_events.xpt
-@BINPATH@/components/content_geckomediaplugins.xpt
-@BINPATH@/components/content_html.xpt
-@BINPATH@/components/content_webrtc.xpt
-@BINPATH@/components/content_xslt.xpt
-@BINPATH@/components/directory.xpt
-@BINPATH@/components/docshell.xpt
-@BINPATH@/components/dom.xpt
-@BINPATH@/components/dom_audiochannel.xpt
-@BINPATH@/components/dom_base.xpt
-@BINPATH@/components/dom_bindings.xpt
-#ifdef MOZ_DEBUG
-@BINPATH@/components/dom_bindings_test.xpt
-#endif
-@BINPATH@/components/dom_core.xpt
-@BINPATH@/components/dom_events.xpt
-@BINPATH@/components/dom_file.xpt
-@BINPATH@/components/dom_geolocation.xpt
-@BINPATH@/components/dom_media.xpt
-@BINPATH@/components/dom_network.xpt
-@BINPATH@/components/dom_notification.xpt
-@BINPATH@/components/dom_html.xpt
-@BINPATH@/components/dom_offline.xpt
-@BINPATH@/components/dom_payments.xpt
-@BINPATH@/components/dom_power.xpt
-@BINPATH@/components/dom_push.xpt
-@BINPATH@/components/dom_quota.xpt
-@BINPATH@/components/dom_range.xpt
-@BINPATH@/components/dom_security.xpt
-@BINPATH@/components/dom_sidebar.xpt
-@BINPATH@/components/dom_storage.xpt
-@BINPATH@/components/dom_system.xpt
-#ifdef MOZ_WEBSPEECH
-@BINPATH@/components/dom_webspeechrecognition.xpt
-#endif
-@BINPATH@/components/dom_workers.xpt
-@BINPATH@/components/dom_xul.xpt
-@BINPATH@/components/dom_presentation.xpt
-@BINPATH@/components/downloads.xpt
-@BINPATH@/components/editor.xpt
-@BINPATH@/components/embedLite.xpt
-@BINPATH@/components/extensions.xpt
-@BINPATH@/components/exthandler.xpt
-@BINPATH@/components/fastfind.xpt
-@BINPATH@/components/feeds.xpt
-@BINPATH@/components/gfx.xpt
-@BINPATH@/components/gtkqticonsconverter.xpt
-@BINPATH@/components/html5.xpt
-@BINPATH@/components/htmlparser.xpt
-@BINPATH@/components/imglib2.xpt
-@BINPATH@/components/inspector.xpt
-@BINPATH@/components/intl.xpt
-@BINPATH@/components/jar.xpt
-@BINPATH@/components/jsdebugger.xpt
-@BINPATH@/components/jsinspector.xpt
-@BINPATH@/components/layout_base.xpt
-#ifdef NS_PRINTING
-@BINPATH@/components/layout_printing.xpt
-#endif
-@BINPATH@/components/layout_xul_tree.xpt
-@BINPATH@/components/layout_xul.xpt
-@BINPATH@/components/locale.xpt
-@BINPATH@/components/mimetype.xpt
-@BINPATH@/components/mozfind.xpt
-@BINPATH@/components/mozintl.xpt
-@BINPATH@/components/necko_about.xpt
-@BINPATH@/components/necko_cache.xpt
-@BINPATH@/components/necko_cache2.xpt
-@BINPATH@/components/necko_cookie.xpt
-@BINPATH@/components/necko_dns.xpt
-@BINPATH@/components/necko_file.xpt
-@BINPATH@/components/necko_ftp.xpt
-@BINPATH@/components/necko_http.xpt
-@BINPATH@/components/necko_mdns.xpt
-@BINPATH@/components/necko_res.xpt
-@BINPATH@/components/necko_socket.xpt
-@BINPATH@/components/necko_strconv.xpt
-@BINPATH@/components/necko_viewsource.xpt
-@BINPATH@/components/necko_websocket.xpt
-#ifdef NECKO_WIFI
-@BINPATH@/components/necko_wifi.xpt
-#endif
-@BINPATH@/components/necko_wyciwyg.xpt
-@BINPATH@/components/necko.xpt
-@BINPATH@/components/loginmgr.xpt
-@BINPATH@/components/parentalcontrols.xpt
-#ifdef MOZ_WEBRTC
-@BINPATH@/components/peerconnection.xpt
-#endif
-@BINPATH@/components/pipnss.xpt
-@BINPATH@/components/pippki.xpt
-@BINPATH@/components/places.xpt
-@BINPATH@/components/plugin.xpt
-@BINPATH@/components/pref.xpt
-@BINPATH@/components/prefetch.xpt
-@BINPATH@/components/privatebrowsing.xpt
-#ifdef MOZ_GECKO_PROFILER
-@BINPATH@/components/profiler.xpt
-#endif
-@BINPATH@/components/rdf.xpt
-@BINPATH@/components/reputationservice.xpt
-@BINPATH@/components/satchel.xpt
-@BINPATH@/components/saxparser.xpt
-@BINPATH@/components/services-crypto-component.xpt
-@BINPATH@/components/services_fxaccounts.xpt
-@BINPATH@/components/captivedetect.xpt
-@BINPATH@/components/shistory.xpt
-@BINPATH@/components/spellchecker.xpt
-@BINPATH@/components/storage.xpt
-@BINPATH@/components/telemetry.xpt
-@BINPATH@/components/toolkit_asyncshutdown.xpt
-@BINPATH@/components/toolkit_filewatcher.xpt
-@BINPATH@/components/toolkit_finalizationwitness.xpt
-@BINPATH@/components/toolkit_osfile.xpt
-@BINPATH@/components/toolkit_securityreporter.xpt
-@BINPATH@/components/toolkit_perfmonitoring.xpt
-@BINPATH@/components/toolkit_xulstore.xpt
-@BINPATH@/components/toolkitprofile.xpt
-#ifdef MOZ_ENABLE_XREMOTE
-@BINPATH@/components/toolkitremote.xpt
-#endif
-@BINPATH@/components/txtsvc.xpt
-@BINPATH@/components/txmgr.xpt
-@BINPATH@/components/uconv.xpt
-@BINPATH@/components/update.xpt
-@BINPATH@/components/uriloader.xpt
-@BINPATH@/components/url-classifier.xpt
-@BINPATH@/components/urlformatter.xpt
-@BINPATH@/components/webBrowser_core.xpt
-@BINPATH@/components/webbrowserpersist.xpt
-@BINPATH@/components/webextensions.xpt
-@BINPATH@/components/webvtt.xpt
-@BINPATH@/components/widget.xpt
-@BINPATH@/components/windowcreator.xpt
-@BINPATH@/components/windowwatcher.xpt
-@BINPATH@/components/xpcom_base.xpt
-@BINPATH@/components/xpcom_system.xpt
-@BINPATH@/components/xpcom_components.xpt
-@BINPATH@/components/xpcom_ds.xpt
-@BINPATH@/components/xpcom_io.xpt
-@BINPATH@/components/xpcom_threads.xpt
-@BINPATH@/components/xpcom_xpti.xpt
-@BINPATH@/components/xpconnect.xpt
-@BINPATH@/components/xulapp.xpt
-@BINPATH@/components/xul.xpt
-@BINPATH@/components/zipwriter.xpt
-
 ; JavaScript components
-@BINPATH@/components/ConsoleAPI.manifest
-@BINPATH@/components/ConsoleAPIStorage.js
-@BINPATH@/components/NotificationStorage.js
-@BINPATH@/components/NotificationStorage.manifest
-@BINPATH@/components/Push.js
-@BINPATH@/components/Push.manifest
-@BINPATH@/components/BrowserElementParent.manifest
-@BINPATH@/components/BrowserElementParent.js
-@BINPATH@/components/FeedProcessor.manifest
-@BINPATH@/components/FeedProcessor.js
-@BINPATH@/components/UAOverridesBootstrapper.js
-@BINPATH@/components/UAOverridesBootstrapper.manifest
-@BINPATH@/components/WellKnownOpportunisticUtils.js
-@BINPATH@/components/WellKnownOpportunisticUtils.manifest
-@BINPATH@/components/mozProtocolHandler.js
-@BINPATH@/components/mozProtocolHandler.manifest
-#ifndef MOZ_GECKOVIEW_JAR
-@BINPATH@/components/nsDNSServiceDiscovery.manifest
-@BINPATH@/components/nsDNSServiceDiscovery.js
-#endif
 @BINPATH@/components/toolkitsearch.manifest
-@BINPATH@/components/nsSearchService.js
-@BINPATH@/components/nsSidebar.js
-@BINPATH@/components/passwordmgr.manifest
-@BINPATH@/components/nsLoginInfo.js
-@BINPATH@/components/nsLoginManager.js
-@BINPATH@/components/crypto-SDR.js
-@BINPATH@/components/TooltipTextProvider.js
-@BINPATH@/components/TooltipTextProvider.manifest
-@BINPATH@/components/NetworkGeolocationProvider.manifest
-@BINPATH@/components/NetworkGeolocationProvider.js
-@BINPATH@/components/EditorUtils.manifest
-@BINPATH@/components/EditorUtils.js
 
 @BINPATH@/components/extensions.manifest
-@BINPATH@/components/addonManager.js
-@BINPATH@/components/nsBlocklistService.js
 
-#ifndef MOZ_GECKOVIEW_JAR
-@BINPATH@/components/utils.manifest
-@BINPATH@/components/simpleServices.js
-@BINPATH@/components/amContentHandler.js
-@BINPATH@/components/amWebAPI.js
-@BINPATH@/components/amInstallTrigger.js
-#ifndef RELEASE_OR_BETA
-@BINPATH@/components/TabSource.js
-#endif
-#endif
+@BINPATH@/components/antitracking.manifest
 
-@BINPATH@/components/webvtt.xpt
-@BINPATH@/components/WebVTT.manifest
-@BINPATH@/components/WebVTTParserWrapper.js
-
-#ifndef MOZ_GECKOVIEW_JAR
-#ifdef MOZ_UPDATER
-@BINPATH@/components/nsUpdateService.manifest
-@BINPATH@/components/nsUpdateService.js
-@BINPATH@/components/nsUpdateServiceStub.js
-#endif
-#endif
-
-@BINPATH@/components/nsUpdateTimerManager.manifest
-@BINPATH@/components/nsUpdateTimerManager.js
-
-@BINPATH@/components/pluginGlue.manifest
 @BINPATH@/components/ProcessSingleton.manifest
-@BINPATH@/components/MainProcessSingleton.js
-@BINPATH@/components/ContentProcessSingleton.js
-@BINPATH@/components/nsURLFormatter.manifest
-@BINPATH@/components/nsURLFormatter.js
-@BINPATH@/components/txEXSLTRegExFunctions.manifest
-@BINPATH@/components/txEXSLTRegExFunctions.js
-@BINPATH@/components/ContentPrefService2.manifest
-@BINPATH@/components/ContentPrefService2.js
-@BINPATH@/components/nsHandlerService-json.manifest
-@BINPATH@/components/nsHandlerService-json.js
-@BINPATH@/components/nsHandlerService.manifest
-@BINPATH@/components/nsHandlerService.js
-@BINPATH@/components/nsWebHandlerApp.manifest
-@BINPATH@/components/nsWebHandlerApp.js
-@BINPATH@/components/satchel.manifest
-@BINPATH@/components/nsFormAutoComplete.js
-@BINPATH@/components/FormHistoryStartup.js
-@BINPATH@/components/nsInputListAutoComplete.js
-@BINPATH@/components/contentAreaDropListener.manifest
-@BINPATH@/components/contentAreaDropListener.js
-@BINPATH@/components/nsINIProcessor.manifest
-@BINPATH@/components/nsINIProcessor.js
+@BINPATH@/components/HandlerService.manifest
+@BINPATH@/components/HandlerService.js
 @BINPATH@/components/servicesComponents.manifest
-
-#ifndef MOZ_GECKOVIEW_JAR
-@BINPATH@/components/TelemetryStartup.js
-@BINPATH@/components/TelemetryStartup.manifest
-#endif
-
-@BINPATH@/components/XULStore.js
-@BINPATH@/components/XULStore.manifest
-@BINPATH@/components/htmlMenuBuilder.js
-@BINPATH@/components/htmlMenuBuilder.manifest
-
-#ifdef MOZ_WEBRTC
-@BINPATH@/components/PeerConnection.js
-@BINPATH@/components/PeerConnection.manifest
-#endif
-
-@BINPATH@/components/CaptivePortalDetectComponents.manifest
-@BINPATH@/components/captivedetect.js
-
-#ifdef MOZ_WEBSPEECH
-@BINPATH@/components/dom_webspeechsynth.xpt
-#endif
+@BINPATH@/components/servicesSettings.manifest
+@BINPATH@/components/l10n-registry.manifest
 
 #if defined(ENABLE_TESTS) && defined(MOZ_DEBUG)
 @BINPATH@/components/TestInterfaceJS.js
@@ -328,46 +88,9 @@
 @BINPATH@/components/TestInterfaceJSMaplike.js
 #endif
 
-@BINPATH@/components/nsAsyncShutdown.manifest
-@BINPATH@/components/nsAsyncShutdown.js
-
-@BINPATH@/components/Downloads.manifest
-@BINPATH@/components/DownloadLegacy.js
-
-#ifndef MOZ_GECKOVIEW_JAR
-@BINPATH@/components/BuiltinProviders.manifest
-@BINPATH@/components/PresentationControlService.js
-@BINPATH@/components/PresentationDataChannelSessionTransport.js
-@BINPATH@/components/PresentationDataChannelSessionTransport.manifest
-#endif
-
-@BINPATH@/components/mozIntl.manifest
-@BINPATH@/components/mozIntl.js
-
 ; Modules
 @BINPATH@/modules/*
-
-; Safe Browsing
-@BINPATH@/components/nsURLClassifier.manifest
-@BINPATH@/components/nsUrlClassifierHashCompleter.js
-@BINPATH@/components/nsUrlClassifierListManager.js
-@BINPATH@/components/nsUrlClassifierLib.js
-@BINPATH@/components/storage-json.js
-@BINPATH@/components/recording-cmdline.manifest
-@BINPATH@/components/recording-cmdline.js
-@BINPATH@/components/terminator.manifest
-@BINPATH@/components/nsTerminatorTelemetry.js
-@BINPATH@/components/nsSearchSuggestions.js
-@BINPATH@/components/url-classifier.xpt
-
-; Private Browsing
-@BINPATH@/components/privatebrowsing.xpt
-@BINPATH@/components/PrivateBrowsing.manifest
-@BINPATH@/components/PrivateBrowsingTrackingProtectionWhitelist.js
-
-; Security Reports
-@BINPATH@/components/SecurityReporter.manifest
-@BINPATH@/components/SecurityReporter.js
+@BINPATH@/actors/*
 
 ; [Browser Chrome Files]
 @BINPATH@/chrome/toolkit@JAREXT@
@@ -375,7 +98,6 @@
 
 ; [Extensions]
 @BINPATH@/components/extensions-toolkit.manifest
-@BINPATH@/components/extension-process-script.js
 
 ; DevTools
 @BINPATH@/chrome/devtools@JAREXT@
@@ -386,7 +108,6 @@
 @BINPATH@/greprefs.js
 @BINPATH@/defaults/autoconfig/prefcalls.js
 @BINPATH@/defaults/pref/embedding.js
-@BINPATH@/defaults/pref/services-common.js
 
 ; [Layout Engine Resources]
 ; Style Sheets, Graphics and other Resources used by the layout engine.
@@ -414,6 +135,10 @@
 @BINPATH@/res/grabber.gif
 @BINPATH@/res/dtd/*
 @BINPATH@/res/language.properties
+@BINPATH@/res/locale/layout/HtmlForm.properties
+@BINPATH@/res/locale/layout/MediaDocument.properties
+@BINPATH@/res/locale/layout/xmlparser.properties
+@BINPATH@/res/locale/dom/dom.properties
 @BINPATH@/res/fonts/*
 
 ; Content-accessible resources.
@@ -422,33 +147,18 @@
 ; svg
 @BINPATH@/res/svg.css
 
-; [Personal Security Manager]
-;
-@BINPATH@/components/pipnss.xpt
-
 ; For process sandboxing
 #if defined(MOZ_SANDBOX)
 @BINPATH@/@DLL_PREFIX@mozsandbox@DLL_SUFFIX@
 #endif
 
-@BINPATH@/components/dom_audiochannel.xpt
-
-@BINPATH@/components/RemoteWebNavigation.js
-@BINPATH@/components/remotebrowserutils.manifest
-
-@BINPATH@/components/FxAccountsComponents.manifest
-@BINPATH@/components/FxAccountsPush.js
-
+; Remote control protocol
 #ifdef ENABLE_MARIONETTE
 @BINPATH@/chrome/marionette@JAREXT@
 @BINPATH@/chrome/marionette.manifest
 @BINPATH@/components/marionette.manifest
 @BINPATH@/components/marionette.js
 #endif
-
-; media (from browser manifest)
-@BINPATH@/gmp-clearkey/0.1/@DLL_PREFIX@clearkey@DLL_SUFFIX@
-@BINPATH@/gmp-clearkey/0.1/manifest.json
 
 #ifdef PKG_LOCALE_MANIFEST
 #include @PKG_LOCALE_MANIFEST@


### PR DESCRIPTION
There are two new folders included to the omni.ja:
- hyphenation
- localization

Seems that Gecko is shifting towards Fluent (*.fl).