### PR TITLE
[sailfishos][embedlite] Adjust embed scroll style. Fixex JB#55306 OMP#JOLLA-322

### DIFF
--- a/embedding/embedlite/tests/content/embedScrollStyles.css
+++ b/embedding/embedlite/tests/content/embedScrollStyles.css
@@ -295,11 +295,3 @@ input[type=number] > div > div, /* work around bug 946184 */
 input[type=number]::-moz-number-spin-box {
   display: none;
 }
-
-%ifdef MOZ_WIDGET_GONK
-/* This binding only provide key shortcuts that we can't use on devices */
-input,
-textarea {
--moz-binding: none !important;
-}
-%endif

--- a/embedding/embedlite/tests/content/embedScrollStyles.css
+++ b/embedding/embedlite/tests/content/embedScrollStyles.css
@@ -10,12 +10,12 @@ xul|window xul|scrollbar {
   display: none;
 }
 
-html xul|scrollbar[root="true"] {
+xul|scrollbar[root="true"] {
   position: relative;
   z-index: 2147483647;
 }
 
-html xul|scrollbar {
+xul|scrollbar {
   -moz-appearance: none !important;
   background-color: transparent !important;
   background-image: none !important;


### PR DESCRIPTION
This will make it possible to utilize fully space on the right hand side.

For testing one can update omni.ja by following steps listed here:
https://sailfishos.org/wiki/WorkingWithBrowser#Debugging_omni.ja_of_gecko
