### PR TITLE
Add dummy preprocessor directive

### DIFF
--- a/embedding/embedlite/tests/content/embedScrollStyles.css
+++ b/embedding/embedlite/tests/content/embedScrollStyles.css
@@ -295,3 +295,6 @@ input[type=number] > div > div, /* work around bug 946184 */
 input[type=number]::-moz-number-spin-box {
   display: none;
 }
+
+%ifdef MOZ_EMBEDLITE
+%endif


### PR DESCRIPTION
[sailfishos][embedlite] Add dummy preprocessor directive. Fixex JB#55306 OMP#JOLLA-322

mozbuild.preprocessor.Error: ('mobile/sailfishos/tests/content/embedScrollStyles.css',
None, 'no preprocessor directives found', None)

sha1 a7ff1cbcd0394dc3febd646fcfdb41733580f0c7 was a bit too much.