### PR TITLE
[sailfishos][embedlite] Call ViewportUtils::GetVisualToLayoutTransform to touch point position. Fixes JB#55472 OMP#JOLLA-365

### DIFF
--- a/embedding/embedlite/utils/BrowserChildHelper.cpp
+++ b/embedding/embedlite/utils/BrowserChildHelper.cpp
@@ -633,7 +633,7 @@ BrowserChildHelper::ApplyPointTransform(const LayoutDevicePoint& aPoint,
                                         uint64_t aInputBlockId,
                                         bool *ok)
 {
-  RefPtr<PresShell> presShell = GetPresShell();
+  RefPtr<PresShell> presShell = GetTopLevelPresShell();
   if (!presShell) {
     if (ok)
       *ok = false;

--- a/embedding/embedlite/utils/BrowserChildHelper.h
+++ b/embedding/embedlite/utils/BrowserChildHelper.h
@@ -176,6 +176,9 @@ private:
   void DispatchMessageManagerMessage(const nsAString& aMessageName,
                                      const nsAString& aJSONData);
 
+  CSSPoint GetVisualToLayoutTransformedPoint(const CSSPoint &aInput,
+                                             const mozilla::layers::ScrollableLayerGuid::ViewID &aScrollId);
+
   friend class EmbedLiteViewThreadChild;
   friend class EmbedLiteViewProcessChild;
   friend class EmbedLiteViewChildIface;


### PR DESCRIPTION
This commit brings back APZCCallbackHelper::ApplyCallbackTransform
that got dropped in commit sha1
https://github.com/sailfishos/gecko-dev/commit/1ae1775925319d69c96e4ca7b4740cd85447a7e9

This follows up changes done to APZCCallbackHelper and ViewportUtils
in context of https://bugzilla.mozilla.org/show_bug.cgi?id=1556556 .

Following changes will depict what's needed:
Bug 1556556 - Move GetCallbackTransform() into a new ViewportUtils class. r=kats
- https://github.com/sailfishos-mirror/gecko-dev/commit/f02fcb17b46f9fdb229f2d17b91c88276a105384

Bug 1556556 - Have GetCallbackTransform take just a scroll id rather than an entire guid. r=kats
- https://github.com/sailfishos-mirror/gecko-dev/commit/6a461317ca50e7bb072ce6b354d2629118ce6a43

Bug 1556556 - Remove APZCCallbackHelper::ApplyCallbackTransform(). r=kats
- https://github.com/sailfishos-mirror/gecko-dev/commit/dd4ac2120da54100aab173387d80f947196ae2a5

Bug 1556556 - Factor out an APZCCallbackHelper::GetCallbackTransform() helper. r=kats
- https://github.com/sailfishos-mirror/gecko-dev/commit/209295c33cdcf926a5c64a721ea3baab33e8dcaa