### PR TITLE
[sailfishos][gecko] Adapt GMP patches from ESR60. JB#55479 OMP#JOLLA-366

### DIFF
--- a/rpm/0023-sailfishos-gecko-Force-to-build-mozglue-and-xpcomglu.patch
+++ b/rpm/0023-sailfishos-gecko-Force-to-build-mozglue-and-xpcomglu.patch
@@ -6,10 +6,24 @@ Subject: [PATCH] [sailfishos][gecko] Force to build mozglue and xpcomglue
 
 Signed-off-by: Pavel Tumakaev <p.tumakaev@omprussia.ru>
 ---
+ config/rules.mk                 | 2 +-
  mozglue/build/moz.build         | 5 +++++
  xpcom/glue/standalone/moz.build | 3 +++
- 2 files changed, 8 insertions(+)
+ 3 files changed, 9 insertions(+), 1 deletion(-)
 
+diff --git a/config/rules.mk b/config/rules.mk
+index c2da8914841e..3b2a0a9ef5bb 100644
+--- a/config/rules.mk
++++ b/config/rules.mk
+@@ -471,7 +471,7 @@ ifdef MSMANIFEST_TOOL
+ 	fi
+ endif	# MSVC with manifest tool
+ else # !WINNT || GNU_CC
+-	$(call EXPAND_CC_OR_CXX,$@) -o $@ $(COMPUTED_CXX_LDFLAGS) $(PGO_CFLAGS) $($(notdir $@)_OBJS) $(RESFILE) $(WIN32_EXE_LDFLAGS) $(LDFLAGS) $(STATIC_LIBS) $(MOZ_PROGRAM_LDFLAGS) $(SHARED_LIBS) $(OS_LIBS)
++	$(call EXPAND_CC_OR_CXX,$@) -o $@ $(COMPUTED_CXX_LDFLAGS) $(PGO_CFLAGS) $($(notdir $@)_OBJS) $(RESFILE) $(WIN32_EXE_LDFLAGS) $(LDFLAGS) -Wl,--whole-archive $(STATIC_LIBS) -Wl,--no-whole-archive $(MOZ_PROGRAM_LDFLAGS) $(SHARED_LIBS) $(OS_LIBS)
+ 	$(call py_action,check_binary,--target $@)
+ endif # WINNT && !GNU_CC
+ 
 diff --git a/mozglue/build/moz.build b/mozglue/build/moz.build
 index ab0cff86fafc..855b7dfa1ea3 100644
 --- a/mozglue/build/moz.build
@@ -53,5 +67,5 @@ index 1c6c83d1b284..952b37cf65e0 100644
  
  if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gtk':
 -- 
-2.25.1
+2.26.2
 

--- a/rpm/0046-sailfishos-gecko-Prioritize-GMP-plugins-over-all-oth.patch
+++ b/rpm/0046-sailfishos-gecko-Prioritize-GMP-plugins-over-all-oth.patch
@@ -8,46 +8,46 @@ Automatically load gmp-droid at startup
 
 Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>
 ---
- dom/media/platforms/PDMFactory.cpp               | 13 +++++++------
+ dom/media/platforms/PDMFactory.cpp               | 13 ++++++-------
  .../platforms/agnostic/gmp/GMPDecoderModule.cpp  | 16 ++++++++++++++++
- 2 files changed, 23 insertions(+), 6 deletions(-)
+ 2 files changed, 22 insertions(+), 7 deletions(-)
 
 diff --git a/dom/media/platforms/PDMFactory.cpp b/dom/media/platforms/PDMFactory.cpp
-index c8e7df236d1b..d47ec17b42af 100644
+index 78ef3f8916fb..268b9f90b007 100644
 --- a/dom/media/platforms/PDMFactory.cpp
 +++ b/dom/media/platforms/PDMFactory.cpp
-@@ -316,6 +316,12 @@ void PDMFactory::CreatePDMs() {
-     return;
+@@ -349,6 +349,12 @@ void PDMFactory::CreatePDMs() {
+     StartupPDM(m);
    }
  
-+  if (MediaPrefs::PDMGMPEnabled()) {
++  if (StaticPrefs::media_gmp_decoder_enabled()) {
 +    m = new GMPDecoderModule();
 +    mGMPPDMFailedToStartup = !StartupPDM(m);
 +  } else {
 +    mGMPPDMFailedToStartup = false;
 +  }
  #ifdef XP_WIN
-   if (MediaPrefs::PDMWMFEnabled() && !IsWin7AndPre2000Compatible()) {
+   if (StaticPrefs::media_wmf_enabled() && !IsWin7AndPre2000Compatible()) {
      m = new WMFDecoderModule();
-@@ -354,12 +360,7 @@ void PDMFactory::CreatePDMs() {
+@@ -393,13 +399,6 @@ void PDMFactory::CreatePDMs() {
+ 
    m = new AgnosticDecoderModule();
    StartupPDM(m);
- 
--  if (MediaPrefs::PDMGMPEnabled()) {
+-
+-  if (StaticPrefs::media_gmp_decoder_enabled()) {
 -    m = new GMPDecoderModule();
 -    mGMPPDMFailedToStartup = !StartupPDM(m);
 -  } else {
 -    mGMPPDMFailedToStartup = false;
 -  }
-+
  }
  
  void PDMFactory::CreateNullPDM() {
 diff --git a/dom/media/platforms/agnostic/gmp/GMPDecoderModule.cpp b/dom/media/platforms/agnostic/gmp/GMPDecoderModule.cpp
-index 7f7fb437ee0a..291f0334767c 100644
+index f4c6e5719737..86b018f5745a 100644
 --- a/dom/media/platforms/agnostic/gmp/GMPDecoderModule.cpp
 +++ b/dom/media/platforms/agnostic/gmp/GMPDecoderModule.cpp
-@@ -88,6 +88,22 @@ bool GMPDecoderModule::SupportsMimeType(const nsACString& aMimeType,
+@@ -86,6 +86,22 @@ bool GMPDecoderModule::SupportsMimeType(const nsACString& aMimeType,
  
  bool GMPDecoderModule::SupportsMimeType(
      const nsACString& aMimeType, DecoderDoctorDiagnostics* aDiagnostics) const {

--- a/rpm/0047-sailfishos-gecko-Force-recycling-of-gmp-droid-instan.patch
+++ b/rpm/0047-sailfishos-gecko-Force-recycling-of-gmp-droid-instan.patch
@@ -13,7 +13,7 @@ decoder recycling.
  1 file changed, 3 insertions(+)
 
 diff --git a/dom/media/platforms/agnostic/gmp/GMPVideoDecoder.h b/dom/media/platforms/agnostic/gmp/GMPVideoDecoder.h
-index e9f08436fdc9..e1d15bdd9fd9 100644
+index 3619eed456d0..38ca7a9b8f7c 100644
 --- a/dom/media/platforms/agnostic/gmp/GMPVideoDecoder.h
 +++ b/dom/media/platforms/agnostic/gmp/GMPVideoDecoder.h
 @@ -42,6 +42,9 @@ class GMPVideoDecoder : public MediaDataDecoder,

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -91,6 +91,8 @@ Patch42:    0042-sailfishos-gecko-Avoid-incorrect-compiler-optimisati.patch
 Patch43:    0043-sailfishos-gecko-Drop-static-casting-from-BrowserChi.patch
 Patch44:    0044-sailfishos-docshell-Get-ContentFrameMessageManager-v.patch
 Patch45:    0045-Revert-Bug-1445570-Remove-EnsureEventualAfterPaint-t.patch
+Patch46:    0046-sailfishos-gecko-Prioritize-GMP-plugins-over-all-oth.patch
+Patch47:    0047-sailfishos-gecko-Force-recycling-of-gmp-droid-instan.patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch
 #Patch12:    0012-sailfishos-build-Fix-build-error-with-newer-glibc.patch
@@ -106,7 +108,6 @@ Patch45:    0045-Revert-Bug-1445570-Remove-EnsureEventualAfterPaint-t.patch
 #Patch26:    0026-sailfishos-gecko-Disable-loading-heavier-extensions.patch
 #Patch28:    0028-sailfishos-gecko-Avoid-rogue-origin-points-when-clip.patch
 #Patch29:    0029-sailfishos-gecko-Allow-render-shaders-to-be-loaded-f.patch
-#Patch30:    0030-sailfishos-gecko-Prioritize-GMP-plugins-over-all-oth.patch
 #Patch31:    0031-sailfishos-gecko-Delete-startupCache-if-it-s-stale.patch
 #Patch33:    0033-sailfishos-gecko-Skip-invalid-WatchId-in-geolocation.patch
 #Patch34:    0034-sailfishos-locale-Get-12-24h-timeformat-setting-from.patch
@@ -121,7 +122,6 @@ Patch45:    0045-Revert-Bug-1445570-Remove-EnsureEventualAfterPaint-t.patch
 #Patch43:    0043-sailfishos-gecko-Prioritize-loading-of-extension-ver.patch
 #Patch44:    0044-sailfishos-media-Ensure-audio-continues-when-screen-.patch
 #Patch45:    0045-sailfishos-backport--Make-MOZSIGNALTRAMPOLINE-Andro-.patch
-#Patch46:    0046-sailfishos-gecko-Force-recycling-of-gmpdroid-instanc.patch
 #Patch47:    0047-sailfishos-gecko-Hardcode-loopback-address-for-profi.patch
 #Patch48:    0048-sailfishos-backport-Enable-MOZ_GECKO_PROFILER-on-And.patch
 #Patch49:    0049-sailfishos-backport-Implement-DWARF-stack-walker-for.patch


### PR DESCRIPTION
Rebase patches and fix a crash in plugin-container resulting from
mozglue being a static library and unreferenced symbols being excluded.