### PR TITLE
Update submodule to new gecko-dev mirror. Fixes JB#55712 OMP#JOLLA-406

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gecko-dev"]
 	path = gecko-dev
-	url = https://git.sailfishos.org/mirror/gecko-dev.git
+	url = https://github.com/sailfishos-mirror/gecko-dev.git


### PR DESCRIPTION
Updates the gecko-dev submodule to the new mirror at

https://github.com/sailfishos-mirror/gecko-dev.git

After pulling down this change, the following must be run in your local
repostory to propagate the change.

git submodule sync --recursive