### PR TITLE
[sailfishos][egl] Drop swap_buffers_with_damage extension support. Fixes JB#55571 OMP#JOLLA-396

### DIFF
--- a/rpm/0048-sailfishos-egl-Drop-swap_buffers_with_damage-extensi.patch
+++ b/rpm/0048-sailfishos-egl-Drop-swap_buffers_with_damage-extensi.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raine Makelainen <raine.makelainen@jolla.com>
+Date: Tue, 28 Sep 2021 09:42:30 +0300
+Subject: [PATCH] [sailfishos][egl] Drop swap_buffers_with_damage extension
+ support. Fixes JB#55571 OMP#JOLLA-396
+
+At least on "Adreno (TM) 508" swapping with damage triggered a hang on the
+compositor thread i.e. call never returns. Conceptually I think we should
+bind eglSwapBuffersWithDamage on hybris side to the eglSwapBuffers.
+
+Co-authored-by: David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
+Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>
+---
+ gfx/gl/GLLibraryEGL.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gfx/gl/GLLibraryEGL.cpp b/gfx/gl/GLLibraryEGL.cpp
+index 13b69f2427c1..a07b8d983ab7 100644
+--- a/gfx/gl/GLLibraryEGL.cpp
++++ b/gfx/gl/GLLibraryEGL.cpp
+@@ -713,7 +713,7 @@ bool GLLibraryEGL::DoEnsureInitialized(bool forceAccel,
+         {(PRFuncPtr*)&mSymbols.fSwapBuffersWithDamage,
+          {{"eglSwapBuffersWithDamageEXT"}}},
+         END_OF_SYMBOLS};
+-    if (!fnLoadSymbols(symbols)) {
++    if (!fnLoadSymbols(symbols) || true) {
+       NS_ERROR(
+           "EGL supports EXT_swap_buffers_with_damage without exposing its "
+           "functions!");
+@@ -726,7 +726,7 @@ bool GLLibraryEGL::DoEnsureInitialized(bool forceAccel,
+         {(PRFuncPtr*)&mSymbols.fSwapBuffersWithDamage,
+          {{"eglSwapBuffersWithDamageKHR"}}},
+         END_OF_SYMBOLS};
+-    if (!fnLoadSymbols(symbols)) {
++    if (!fnLoadSymbols(symbols) || true) {
+       NS_ERROR(
+           "EGL supports KHR_swap_buffers_with_damage without exposing its "
+           "functions!");
+-- 
+2.31.1
+

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -93,6 +93,7 @@ Patch44:    0044-sailfishos-docshell-Get-ContentFrameMessageManager-v.patch
 Patch45:    0045-Revert-Bug-1445570-Remove-EnsureEventualAfterPaint-t.patch
 Patch46:    0046-sailfishos-gecko-Prioritize-GMP-plugins-over-all-oth.patch
 Patch47:    0047-sailfishos-gecko-Force-recycling-of-gmp-droid-instan.patch
+Patch48:    0048-sailfishos-egl-Drop-swap_buffers_with_damage-extensi.patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch
 #Patch12:    0012-sailfishos-build-Fix-build-error-with-newer-glibc.patch


### PR DESCRIPTION
At least on "Adreno (TM) 508" swapping with damage triggered a hang on the
compositor thread i.e. call never returns. Conceptually I think we should
bind eglSwapBuffersWithDamage on hybris side to the eglSwapBuffers or something like that.

Co-authored-by: David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>