### PR TITLE
[sailfishos][embedlite] Reset toolbar height after vkb closes. Fixes JB#55497 OMP#JOLLA-382

### DIFF
--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -706,11 +706,13 @@ mozilla::ipc::IPCResult EmbedLiteViewChild::RecvSetVirtualKeyboardHeight(const i
 {
   LOGT("aHeight:%i", aHeight);
 
-  mVirtualKeyboardHeight = aHeight;
-
-  if (mVirtualKeyboardHeight) {
+  if (aHeight != mVirtualKeyboardHeight) {
+    mVirtualKeyboardHeight = aHeight;
     mHelper->DynamicToolbarMaxHeightChanged(aHeight);
-    ScrollInputFieldIntoView();
+
+    if (mVirtualKeyboardHeight) {
+      ScrollInputFieldIntoView();
+    }
   }
   return IPC_OK();
 }


### PR DESCRIPTION
When vkb closes its height is set to zero but toolbar height was not changed, this fixes that.