### PR TITLE
[sailfishos][embedlite] Define extensions.systemAddon.update.enabled as false. Fixes JB#55751 OMP#JOLLA-416

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -122,6 +122,8 @@ pref("embedlite.compositor.external_gl_context", false);
 // this pref only makes sense when using external compositor gl context.
 pref("embedlite.compositor.request_external_gl_context_early", false);
 pref("extensions.update.enabled", false);
+pref("extensions.systemAddon.update.enabled", false);
+
 pref("toolkit.storage.synchronous", 0);
 /* new html5 forms */
 // Support for input type=color. By default, disabled.


### PR DESCRIPTION
There is no default value in the all.js. Hence, following error
could occur:

1633050956927	addons.manager	WARN	Error in background update: [Exception... "Component returned failure code: 0x8000ffff (NS_ERROR_UNEXPECTED) [nsIPrefBranch.getBoolPref]"  nsresult: "0x8000ffff (NS_ERROR_UNEXPECTED)"  location: "JS frame :: resource://gre/modules/AddonManager.jsm :: systemUpdateEnabled :: line 1287"  data: no] Stack trace: systemUpdateEnabled()@resource://gre/modules/AddonManager.jsm:1287
backgroundUpdateCheck/buPromise<()@resource://gre/modules/AddonManager.jsm:1366
backgroundUpdateCheck()@resource://gre/modules/AddonManager.jsm:1378
backgroundUpdateTimerHandler()@resource://gre/modules/AddonManager.jsm:3502
notify()@resource://gre/modules/addonManager.js:174
TM_notify/<()@resource://gre/modules/UpdateTimerManager.jsm:219
TM_notify()@resource://gre/modules/UpdateTimerManager.jsm:290

This make now sure that we have extensions.systemAddon.update.enabled
defined making sure that reading of the pref succeeds.