### PR TITLE
Adapt window.open and window.close to work

### DIFF
--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.h
@@ -226,9 +226,11 @@ private:
   void SetDesktopMode(const bool aDesktopMode);
   bool SetDesktopModeInternal(const bool aDesktopMode);
 
+  mozilla::dom::BrowsingContext *GetBrowsingContext() const;
+
   uint32_t mId;
   uint64_t mOuterId;
-  EmbedLiteWindowChild* mWindow; // Not owned
+  EmbedLiteWindowChild *mWindow; // Not owned
   nsCOMPtr<nsIWidget> mWidget;
   RefPtr<nsWebBrowser> mWebBrowser;
   nsCOMPtr<nsIIdleServiceInternal> mIdleService;

--- a/embedding/embedlite/utils/WebBrowserChrome.cpp
+++ b/embedding/embedlite/utils/WebBrowserChrome.cpp
@@ -174,6 +174,13 @@ NS_IMETHODIMP WebBrowserChrome::SetChromeFlags(uint32_t aChromeFlags)
   return NS_OK;
 }
 
+NS_IMETHODIMP WebBrowserChrome::DestroyBrowserWindow()
+{
+  LOGT();
+  mListener->OnWindowCloseRequested();
+  return NS_OK;
+}
+
 NS_IMETHODIMP WebBrowserChrome::ShowAsModal()
 {
   LOGNI();

--- a/rpm/0049-Revert-Bug-1494175-Remove-unimplemented-nsIWebBrowse.patch
+++ b/rpm/0049-Revert-Bug-1494175-Remove-unimplemented-nsIWebBrowse.patch
@@ -1,0 +1,109 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raine Makelainen <raine.makelainen@jolla.com>
+Date: Fri, 1 Oct 2021 13:52:17 +0300
+Subject: [PATCH] Revert "Bug 1494175 - Remove unimplemented
+ nsIWebBrowserChrome methods. r=qdot"
+
+This partially reverts commit 578ac09f67274b520071a3ef0052405cde0ef9f0.
+
+Sailfish OS embedding requires destroyBrowserWindow to handle
+window.close (OnWindowCloseRequested).
+
+Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>
+---
+ docshell/base/nsDocShellTreeOwner.cpp              | 5 +----
+ dom/ipc/BrowserChild.cpp                           | 8 ++++++++
+ toolkit/components/browser/nsIWebBrowserChrome.idl | 6 ++++++
+ xpfe/appshell/nsAppShellService.cpp                | 7 +++++++
+ xpfe/appshell/nsContentTreeOwner.cpp               | 5 +++++
+ 5 files changed, 27 insertions(+), 4 deletions(-)
+
+diff --git a/docshell/base/nsDocShellTreeOwner.cpp b/docshell/base/nsDocShellTreeOwner.cpp
+index 0e6e11605b24..cfd4f035ff53 100644
+--- a/docshell/base/nsDocShellTreeOwner.cpp
++++ b/docshell/base/nsDocShellTreeOwner.cpp
+@@ -447,10 +447,7 @@ NS_IMETHODIMP
+ nsDocShellTreeOwner::Destroy() {
+   nsCOMPtr<nsIWebBrowserChrome> webBrowserChrome = GetWebBrowserChrome();
+   if (webBrowserChrome) {
+-    // XXX: this is weird, but we used to call a method here
+-    // (webBrowserChrome->DestroyBrowserWindow()) whose implementations all
+-    // failed like this, so...
+-    return NS_ERROR_NOT_IMPLEMENTED;
++    return webBrowserChrome->DestroyBrowserWindow();
+   }
+ 
+   return NS_ERROR_NULL_POINTER;
+diff --git a/dom/ipc/BrowserChild.cpp b/dom/ipc/BrowserChild.cpp
+index 2b17323d8a93..b1e658a2dc87 100644
+--- a/dom/ipc/BrowserChild.cpp
++++ b/dom/ipc/BrowserChild.cpp
+@@ -652,6 +652,14 @@ BrowserChild::SetChromeFlags(uint32_t aChromeFlags) {
+   return NS_ERROR_NOT_IMPLEMENTED;
+ }
+ 
++NS_IMETHODIMP
++BrowserChild::DestroyBrowserWindow()
++{
++  NS_WARNING("BrowserChild::DestroyBrowserWindow not supported in BrowserChild");
++
++  return NS_ERROR_NOT_IMPLEMENTED;
++}
++
+ NS_IMETHODIMP
+ BrowserChild::RemoteSizeShellTo(int32_t aWidth, int32_t aHeight,
+                                 int32_t aShellItemWidth,
+diff --git a/toolkit/components/browser/nsIWebBrowserChrome.idl b/toolkit/components/browser/nsIWebBrowserChrome.idl
+index 1e9bea1655af..b4cbfc32933d 100644
+--- a/toolkit/components/browser/nsIWebBrowserChrome.idl
++++ b/toolkit/components/browser/nsIWebBrowserChrome.idl
+@@ -98,6 +98,12 @@ interface nsIWebBrowserChrome : nsISupports
+      */
+     attribute unsigned long chromeFlags;
+ 
++    /**
++     * Asks the implementer to destroy the window associated with this
++     * WebBrowser object.
++     */
++    void destroyBrowserWindow();
++
+     /**
+      * Shows the window as a modal window.
+      */
+diff --git a/xpfe/appshell/nsAppShellService.cpp b/xpfe/appshell/nsAppShellService.cpp
+index 719684ceb072..cdfaba6b0528 100644
+--- a/xpfe/appshell/nsAppShellService.cpp
++++ b/xpfe/appshell/nsAppShellService.cpp
+@@ -230,6 +230,13 @@ WebBrowserChrome2Stub::SetChromeFlags(uint32_t aChromeFlags) {
+   return NS_ERROR_NOT_IMPLEMENTED;
+ }
+ 
++NS_IMETHODIMP
++WebBrowserChrome2Stub::DestroyBrowserWindow() {
++  MOZ_ASSERT_UNREACHABLE("WebBrowserChrome2Stub::DestroyBrowserWindow is "
++                         "not supported");
++  return NS_ERROR_NOT_IMPLEMENTED;
++}
++
+ NS_IMETHODIMP
+ WebBrowserChrome2Stub::ShowAsModal() {
+   MOZ_ASSERT_UNREACHABLE("WebBrowserChrome2Stub::ShowAsModal is not supported");
+diff --git a/xpfe/appshell/nsContentTreeOwner.cpp b/xpfe/appshell/nsContentTreeOwner.cpp
+index ee829bec78e5..6e585212ddd6 100644
+--- a/xpfe/appshell/nsContentTreeOwner.cpp
++++ b/xpfe/appshell/nsContentTreeOwner.cpp
+@@ -456,6 +456,11 @@ NS_IMETHODIMP nsContentTreeOwner::IsWindowModal(bool* _retval) {
+   return NS_OK;
+ }
+ 
++NS_IMETHODIMP nsContentTreeOwner::DestroyBrowserWindow() {
++   NS_ERROR("Haven't Implemented this yet");
++   return NS_ERROR_FAILURE;
++}
++
+ //*****************************************************************************
+ // nsContentTreeOwner::nsIBaseWindow
+ //*****************************************************************************
+-- 
+2.31.1
+

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -101,6 +101,7 @@ Patch45:    0045-Revert-Bug-1445570-Remove-EnsureEventualAfterPaint-t.patch
 Patch46:    0046-sailfishos-gecko-Prioritize-GMP-plugins-over-all-oth.patch
 Patch47:    0047-sailfishos-gecko-Force-recycling-of-gmp-droid-instan.patch
 Patch48:    0048-sailfishos-egl-Drop-swap_buffers_with_damage-extensi.patch
+Patch49:    0049-Revert-Bug-1494175-Remove-unimplemented-nsIWebBrowse.patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch
 #Patch12:    0012-sailfishos-build-Fix-build-error-with-newer-glibc.patch


### PR DESCRIPTION
This PR contains 3 commits

1) Pass parent browsing context to a child view that is created with window.open

2) Partially Revert "Bug 1494175 - Remove unimplementet nsIWebBrowserChrome methods" to make window.close to work again: https://github.com/sailfishos-mirror/gecko-dev/commit/578ac09f67274b520071a3ef0052405cde0ef9f0

3) Introduce back DestroyBrowserWindow method implementation

On context of debugging 1st commit and why window.close was not working it became clear that nsGlobalWindowOuter::ReallyCloseWindow and treeOwnerAsWin->Destroy() didn't do anything. 