### PR TITLE
[sailfishos][embedlite] Fix child actor services not receiving events. JB#55484 OMP#JOLLA-371

### DIFF
--- a/embedding/embedlite/utils/BrowserChildHelper.cpp
+++ b/embedding/embedlite/utils/BrowserChildHelper.cpp
@@ -19,6 +19,7 @@
 #include "mozilla/dom/MessageManagerBinding.h"
 #include "mozilla/dom/ipc/StructuredCloneData.h"
 #include "mozilla/dom/DocumentInlines.h"
+#include "mozilla/dom/JSActorService.h"
 
 #include "nsNetUtil.h"
 #include "nsIDOMWindowUtils.h"
@@ -260,6 +261,9 @@ BrowserChildHelper::InitBrowserChildHelperMessageManager()
     return false;
   }
   root->SetParentTarget(scope);
+
+  RefPtr<JSActorService> wasvc = JSActorService::GetSingleton();
+  wasvc->RegisterChromeEventTarget(scope);
 
   return true;
 }

--- a/rpm/0050-sailfishos-gecko-Force-use-of-mobile-video-controls..patch
+++ b/rpm/0050-sailfishos-gecko-Force-use-of-mobile-video-controls..patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew den Exter <andrew.den.exter@jolla.com>
+Date: Fri, 1 Oct 2021 06:57:53 +0000
+Subject: [PATCH] [sailfishos][gecko] Force use of mobile video controls.
+ JB#55484 OMP#JOLLA-371
+
+---
+ toolkit/content/widgets/videocontrols.js | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/toolkit/content/widgets/videocontrols.js b/toolkit/content/widgets/videocontrols.js
+index 0b41769f680c..ca4ac7203ba8 100644
+--- a/toolkit/content/widgets/videocontrols.js
++++ b/toolkit/content/widgets/videocontrols.js
+@@ -19,7 +19,7 @@ this.VideoControlsWidget = class {
+     this.document = this.element.ownerDocument;
+     this.window = this.document.defaultView;
+ 
+-    this.isMobile = this.window.navigator.appVersion.includes("Android");
++    this.isMobile = true;
+   }
+ 
+   /*
+@@ -2320,7 +2320,7 @@ this.VideoControlsImplWidget = class {
+           )[0];
+         }
+ 
+-        let isMobile = this.window.navigator.appVersion.includes("Android");
++        let isMobile = true
+         if (isMobile) {
+           this.controlsContainer.classList.add("mobile");
+         }
+@@ -2798,7 +2798,7 @@ this.NoControlsMobileImplWidget = class {
+           "controlsContainer"
+         );
+ 
+-        let isMobile = this.window.navigator.appVersion.includes("Android");
++        let isMobile = true;
+         if (isMobile) {
+           this.controlsContainer.classList.add("mobile");
+         }
+-- 
+2.26.2
+

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -102,6 +102,7 @@ Patch46:    0046-sailfishos-gecko-Prioritize-GMP-plugins-over-all-oth.patch
 Patch47:    0047-sailfishos-gecko-Force-recycling-of-gmp-droid-instan.patch
 Patch48:    0048-sailfishos-egl-Drop-swap_buffers_with_damage-extensi.patch
 Patch49:    0049-Revert-Bug-1494175-Remove-unimplemented-nsIWebBrowse.patch
+Patch50:    0050-sailfishos-gecko-Force-use-of-mobile-video-controls..patch
 #Patch10:    0010-sailfishos-gecko-Remove-PuppetWidget-from-TabChild-i.patch
 #Patch11:    0011-sailfishos-gecko-Make-TabChild-to-work-with-TabChild.patch
 #Patch12:    0012-sailfishos-build-Fix-build-error-with-newer-glibc.patch


### PR DESCRIPTION
The embedlite message manager needs to be registered with JSActorService. And then the mobile variant of the controls should be favored for Sailfish.