### PR TITLE
[sailfishos][embedlite] Add string formatted component CID in comments

### DIFF
--- a/embedding/embedlite/components/nsClipboard.h
+++ b/embedding/embedlite/components/nsClipboard.h
@@ -36,6 +36,7 @@ private:
     bool mActive;
 };
 
+// b27ca13c-b6d5-11e2-b8c8-1b7d857709
 #define NS_EMBED_CLIPBOARD_SERVICE_CID \
 { 0xb27ca13c, \
   0xb6d5, \

--- a/embedding/embedlite/modules/EmbedLiteAppService.h
+++ b/embedding/embedlite/modules/EmbedLiteAppService.h
@@ -42,6 +42,7 @@ private:
   bool mHandlingMessages;
 };
 
+// 3960150c-6e89-11e2-90b3-631813f021
 #define NS_EMBED_LITE_APP_CONTRACTID "@mozilla.org/embedlite-app-service;1"
 #define NS_EMBED_LITE_APP_SERVICE_CLASSNAME "EmbedLiteApp Component"
 #define NS_EMBED_LITE_APP_SERVICE_CID \


### PR DESCRIPTION
This helps when logging with MOZ_LOG="nsComponentManager:5" and
checking loaded / created components.