### PR TITLE
[sailfishos][embedlite] Use StaticXREAppData to read application.ini. Fixes JB#55883 OMP#JOLLA-436

### DIFF
--- a/embedding/embedlite/moz.build
+++ b/embedding/embedlite/moz.build
@@ -109,6 +109,7 @@ IPDL_SOURCES += [
 ]
 
 LOCAL_INCLUDES += [
+    '!/build',
     '/dom/base',
     '/dom/ipc',
     '/gfx/layers',

--- a/embedding/embedlite/utils/EmbedLiteXulAppInfo.cpp
+++ b/embedding/embedlite/utils/EmbedLiteXulAppInfo.cpp
@@ -17,7 +17,7 @@
 #include "nsString.h"
 #include "EmbedLiteAppThreadChild.h"
 
-#include "buildid.h"
+#include "application.ini.h"
 #include "mozilla/Unused.h"
 
 #if defined(ACCESSIBILITY)
@@ -64,13 +64,13 @@ NS_IMETHODIMP EmbedLiteXulAppInfo::GetID(nsACString& aID)
 
 NS_IMETHODIMP EmbedLiteXulAppInfo::GetVersion(nsACString& aVersion)
 {
-  aVersion.Assign(MOZ_STRINGIFY(MOZ_APP_VERSION));
+  aVersion.Assign(sAppData.version);
   return NS_OK;
 }
 
 NS_IMETHODIMP EmbedLiteXulAppInfo::GetAppBuildID(nsACString& aAppBuildID)
 {
-  aAppBuildID.Assign(MOZ_STRINGIFY(MOZ_BUILDID));
+  aAppBuildID.Assign(sAppData.buildID);
   return NS_OK;
 }
 
@@ -94,13 +94,13 @@ NS_IMETHODIMP EmbedLiteXulAppInfo::GetVendor(nsACString& aVendor)
 
 NS_IMETHODIMP EmbedLiteXulAppInfo::GetPlatformVersion(nsACString& aPlatformVersion)
 {
-  aPlatformVersion.Assign(MOZ_STRINGIFY(GRE_MILESTONE));
+  aPlatformVersion.Assign(sAppData.version);
   return NS_OK;
 }
 
 NS_IMETHODIMP EmbedLiteXulAppInfo::GetPlatformBuildID(nsACString& aPlatformBuildID)
 {
-  aPlatformBuildID.Assign(MOZ_STRINGIFY(MOZ_BUILDID));
+  aPlatformBuildID.Assign(sAppData.buildID);
   return NS_OK;
 }
 
@@ -315,12 +315,12 @@ EmbedLiteXulAppInfo::GetIs64Bit(bool* aResult)
 NS_IMETHODIMP
 EmbedLiteXulAppInfo::GetSourceURL(nsACString &aResult)
 {
-  return NS_ERROR_NOT_IMPLEMENTED;
+  return NS_OK;
 }
 
 NS_IMETHODIMP
 EmbedLiteXulAppInfo::GetUpdateURL(nsACString &aResult) {
-  return NS_ERROR_NOT_IMPLEMENTED;
+  return NS_OK;
 }
 
 NS_IMETHODIMP
@@ -338,10 +338,12 @@ EmbedLiteXulAppInfo::GetLauncherProcessState(uint32_t *aResult) {
 
 NS_IMETHODIMP
 EmbedLiteXulAppInfo::GetLastAppVersion(nsACString &aResult) {
-  return NS_ERROR_NOT_IMPLEMENTED;
+  aResult.Assign(sAppData.version);
+  return NS_OK;
 }
 
 NS_IMETHODIMP
 EmbedLiteXulAppInfo::GetLastAppBuildID(nsACString &aResult) {
-  return NS_ERROR_NOT_IMPLEMENTED;
+  aResult.Assign(sAppData.buildID);
+  return NS_OK;
 }


### PR DESCRIPTION
Quote from XREAppData.h:
"A static version of the XRE app data is compiled into the application
so that it is not necessary to read application.ini at startup.

This structure is initialized into and matches nsXREAppData"

If there are issues in future those should be handled by build config and
fixing application.ini generation.

This also marks GetSourceURL and GetUpdateURL as ok and not assigning
anything there.