### PR TITLE
[sailfishos][embedlite] Update dynamic toolbar offset. Fixes JB#56014 OMP#JOLLA-459

### DIFF
--- a/embedding/embedlite/utils/BrowserChildHelper.cpp
+++ b/embedding/embedlite/utils/BrowserChildHelper.cpp
@@ -337,6 +337,7 @@ void BrowserChildHelper::DynamicToolbarMaxHeightChanged(const ScreenIntCoord &aH
 
   if (RefPtr<nsPresContext> presContext = document->GetPresContext()) {
     presContext->SetDynamicToolbarMaxHeight(aHeight);
+    presContext->UpdateDynamicToolbarOffset(0);
   }
 }
 


### PR DESCRIPTION
This update actual dynamic toolbar height and forcibly flushes position:fixed
elements  in the case where the dynamic toolbar is going to be completely
hidden or starts to be visible.

See https://github.com/sailfishos-mirror/gecko-dev/blob/esr78/layout/base/nsPresContext.cpp#L2530