### PR TITLE
[sailfishos][gecko-dev] Fix timeouts when querying location. JB#56073 OMP#JOLLA-483

### DIFF
--- a/rpm/0002-sailfishos-qt-Bring-back-Qt-layer.-JB-50505.patch
+++ b/rpm/0002-sailfishos-qt-Bring-back-Qt-layer.-JB-50505.patch
@@ -242,7 +242,7 @@ Signed-off-by: Pavel Tumakaev <p.tumakaev@omprussia.ru>
  dom/plugins/ipc/PluginModuleParent.cpp        |   12 +-
  dom/plugins/ipc/moz.build                     |    7 +
  dom/system/moz.build                          |    4 +-
- dom/system/qt/QTMLocationProvider.cpp         |  101 +
+ dom/system/qt/QTMLocationProvider.cpp         |  103 +
  dom/system/qt/QTMLocationProvider.h           |   35 +
  dom/system/qt/QtHapticFeedback.cpp            |   20 +
  dom/system/qt/QtHapticFeedback.h              |   15 +
@@ -338,7 +338,7 @@ Signed-off-by: Pavel Tumakaev <p.tumakaev@omprussia.ru>
  widget/qt/nsWidgetFactory.h                   |   22 +
  widget/qt/nsWindow.cpp                        | 1695 +++++++++++++++++
  widget/qt/nsWindow.h                          |  312 +++
- 116 files changed, 7698 insertions(+), 53 deletions(-)
+ 116 files changed, 7700 insertions(+), 53 deletions(-)
  create mode 100644 dom/plugins/ipc/NestedLoopTimer.cpp
  create mode 100644 dom/plugins/ipc/NestedLoopTimer.h
  create mode 100644 dom/plugins/ipc/PluginHelperQt.cpp
@@ -969,10 +969,10 @@ index 095a5f098bd2..92910886be20 100644
      DIRS += ['mac']
 diff --git a/dom/system/qt/QTMLocationProvider.cpp b/dom/system/qt/QTMLocationProvider.cpp
 new file mode 100644
-index 000000000000..335b26632ff9
+index 000000000000..70b1c37dce94
 --- /dev/null
 +++ b/dom/system/qt/QTMLocationProvider.cpp
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,103 @@
 +/* -*- Mode: c++; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
 + * This Source Code Form is subject to the terms of the Mozilla Public
 + * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -983,16 +983,21 @@ index 000000000000..335b26632ff9
 +
 +using namespace mozilla;
 +
++Q_DECLARE_METATYPE(QGeoPositionInfo)
++
 +NS_IMPL_ISUPPORTS(QTMLocationProvider, nsIGeolocationProvider)
 +
 +QTMLocationProvider::QTMLocationProvider()
++    : mLocation(QGeoPositionInfoSource::createDefaultSource(this))
 +{
-+    if (QMetaType::type("QGeoPositionInfo") == QMetaType::UnknownType) {
-+        qRegisterMetaType<QGeoPositionInfo>("QGeoPositionInfo");
++    qRegisterMetaType<QGeoPositionInfo>();
++
++    if (mLocation) {
++        connect(mLocation, &QGeoPositionInfoSource::positionUpdated, this, &QTMLocationProvider::positionUpdated);
++        // Not all versions of qt5positioning set default prefered method
++        // thus this workaround initializing QGeoPositionSource explicitly
++        mLocation->setPreferredPositioningMethods(QGeoPositionInfoSource::AllPositioningMethods);
 +    }
-+    mLocation = QGeoPositionInfoSource::createDefaultSource(this);
-+    if (mLocation)
-+        connect(mLocation, SIGNAL(positionUpdated(QGeoPositionInfo)), this, SLOT(positionUpdated(QGeoPositionInfo)));
 +}
 +
 +QTMLocationProvider::~QTMLocationProvider()
@@ -1023,7 +1028,7 @@ index 000000000000..335b26632ff9
 +        new nsGeoPosition(latitude, longitude,
 +                          altitude, accuracy,
 +                          altitudeAccuracy, heading,
-+                          speed, geoPosition.timestamp().toTime_t());
++                          speed, geoPosition.timestamp().toMSecsSinceEpoch());
 +    if (mCallback) {
 +        mCallback->Update(p);
 +    }
@@ -1035,9 +1040,6 @@ index 000000000000..335b26632ff9
 +    if (!mLocation)
 +        return NS_ERROR_NOT_IMPLEMENTED;
 +
-+    // Not all versions of qt5positioning set default prefered method
-+    // thus this workaround initializing QGeoPositionSource explicitly
-+    SetHighAccuracy(false);
 +    mLocation->startUpdates();
 +
 +    return NS_OK;
@@ -10356,5 +10358,5 @@ index 000000000000..cc46495df180
 +
 +#endif /* __nsWindow_h__ */
 -- 
-2.25.1
+2.26.2
 


### PR DESCRIPTION
Location results were being dropped as being too old as their timestamps were in seconds since the unix epoch and not milliseconds since.