### PR TITLE
[sailfishos][embedlite] Remove unused variable. Contributes to JB#55799

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteCompositorBridgeParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorBridgeParent.cpp
@@ -122,7 +122,6 @@ EmbedLiteCompositorBridgeParent::PrepareOffscreen()
       } else {
         // [Basic Layers, OMTC] WebGL layer init.
         // Well, this *should* work...
-        GLContext* nullConsGL = nullptr; // Bug 1050044.
         factory = MakeUnique<SurfaceFactory_GLTexture>(context, screen->mCaps, nullptr, flags);
       }
       if (factory) {


### PR DESCRIPTION
Previously, the variable existed because a template function could
not accept `nullptr` as a parameter; this was fixed upstream, and
the code was updated to pass `nullptr` directly, but the variable
was never removed, resulting in compiler warning.