### PR TITLE
Fix Security info (secure/unsecure) to appear to the toolbar

### DIFF
--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -37,6 +37,7 @@
 #include "nsIWidgetListener.h"
 #include "mozilla/layers/APZEventState.h"
 #include "APZCCallbackHelper.h"
+#include "mozilla/dom/CanonicalBrowsingContext.h"
 #include "mozilla/dom/Element.h"
 #include "mozilla/dom/Document.h"
 #include "mozilla/dom/LoadURIOptionsBinding.h"
@@ -259,6 +260,15 @@ EmbedLiteViewChild::InitGeckoWindow(const uint32_t parentId, const bool isPrivat
   RefPtr<BrowsingContext> browsingContext = BrowsingContext::CreateDetached(nullptr, parentBrowsingContext, EmptyString(), BrowsingContext::Type::Content);
   browsingContext->SetUsePrivateBrowsing(isPrivateWindow); // Needs to be called before attaching
   browsingContext->EnsureAttached();
+
+  CanonicalBrowsingContext *canonicalBrowsingContext = browsingContext->Canonical();
+  nsISecureBrowserUI *secureBrowserUI = nullptr;
+
+  // Create instance of nsSecureBrowserUI.
+  if (canonicalBrowsingContext) {
+    secureBrowserUI = canonicalBrowsingContext->GetSecureBrowserUI();
+    Unused << secureBrowserUI;
+  }
 
   // nsWebBrowser::Create creates nsDocShell, calls InitWindow for nsIBaseWindow,
   // and finally creates nsIBaseWindow. When browsingContext is passed to

--- a/embedding/embedlite/utils/EmbedLiteSecurity.cpp
+++ b/embedding/embedlite/utils/EmbedLiteSecurity.cpp
@@ -122,10 +122,10 @@ void EmbedLiteSecurity::importState(const char *aStatus, unsigned int aState)
         if (NS_SUCCEEDED(rv))
             d_ptr->mProtocolVersion = static_cast<TLS_VERSION>(protocolVersion);
 
-        Maybe<nsTArray<uint8_t>> certArray;
-        rv = aServerCert->GetRawDER(*certArray);
-        unsigned int length = certArray->Length();
-        void *data = certArray->Elements();
+        nsTArray<uint8_t> certArray;
+        rv = aServerCert->GetRawDER(certArray);
+        unsigned int length = certArray.Length();
+        void *data = certArray.Elements();
 
         if (NS_SUCCEEDED(rv)) {
             if (data) {

--- a/rpm/0077-sailfishos-docshell-Align-fix-parentprocess-checks.-.patch
+++ b/rpm/0077-sailfishos-docshell-Align-fix-parentprocess-checks.-.patch
@@ -1,21 +1,40 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Raine Makelainen <raine.makelainen@jolla.com>
 Date: Mon, 25 Oct 2021 12:53:33 +0300
-Subject: [PATCH] [sailfishos][browserchild] Add parentIsActive attribute to
- the nsIBrowserChild. Fixes JB#56063 OMP#JOLLA-474
+Subject: [PATCH] [sailfishos][docshell] Align / fix parentprocess checks.
+ JB#56074 OMP#JOLLA-482
+
+[sailfishos][docshell] Create CanonicalBrowsingContext. JB#56074 OMP#JOLLA-482
+
+[sailfishos][browserchild] Add parentIsActive attribute to the nsIBrowserChild. Fixes JB#56063 OMP#JOLLA-474
 
 Also make sure that nsDocShell has nsIBrowserChild available.
 
 Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>
 ---
- docshell/base/nsDocShell.cpp            |  2 +-
- dom/base/nsFocusManager.cpp             |  3 ++-
- dom/interfaces/base/nsIBrowserChild.idl |  5 +++++
- dom/ipc/BrowserChild.cpp                | 10 ++++++++++
- 4 files changed, 18 insertions(+), 2 deletions(-)
+ docshell/base/BrowsingContext.cpp          |  2 +-
+ docshell/base/nsDocShell.cpp               |  4 ++--
+ dom/base/nsFocusManager.cpp                |  3 ++-
+ dom/interfaces/base/nsIBrowserChild.idl    |  5 +++++
+ dom/ipc/BrowserChild.cpp                   | 10 ++++++++++
+ security/manager/ssl/nsSecureBrowserUI.cpp |  1 +
+ 6 files changed, 21 insertions(+), 4 deletions(-)
 
+diff --git a/docshell/base/BrowsingContext.cpp b/docshell/base/BrowsingContext.cpp
+index 96d26c98f288..9caf8672bf78 100644
+--- a/docshell/base/BrowsingContext.cpp
++++ b/docshell/base/BrowsingContext.cpp
+@@ -211,7 +211,7 @@ already_AddRefed<BrowsingContext> BrowsingContext::CreateDetached(
+           : BrowsingContextGroup::Select(parentWC, aOpener);
+ 
+   RefPtr<BrowsingContext> context;
+-  if (XRE_IsParentProcess()) {
++  if (true) {
+     context =
+         new CanonicalBrowsingContext(parentWC, group, id,
+                                      /* aOwnerProcessId */ 0,
 diff --git a/docshell/base/nsDocShell.cpp b/docshell/base/nsDocShell.cpp
-index bb7d65805667..ae8b77a80cdc 100644
+index bb7d65805667..b8b4ab4a5c54 100644
 --- a/docshell/base/nsDocShell.cpp
 +++ b/docshell/base/nsDocShell.cpp
 @@ -2695,7 +2695,7 @@ nsDocShell::SetTreeOwner(nsIDocShellTreeOwner* aTreeOwner) {
@@ -27,6 +46,15 @@ index bb7d65805667..ae8b77a80cdc 100644
      nsCOMPtr<nsIBrowserChild> newBrowserChild = do_GetInterface(mTreeOwner);
      MOZ_ASSERT(newBrowserChild,
                 "No BrowserChild actor for tree owner in Content!");
+@@ -5570,7 +5570,7 @@ nsDocShell::OnStateChange(nsIWebProgress* aProgress, nsIRequest* aRequest,
+ NS_IMETHODIMP
+ nsDocShell::OnLocationChange(nsIWebProgress* aProgress, nsIRequest* aRequest,
+                              nsIURI* aURI, uint32_t aFlags) {
+-  if (XRE_IsParentProcess()) {
++  if (true) {
+     // Since we've now changed Documents, notify the BrowsingContext that we've
+     // changed. Ideally we'd just let the BrowsingContext do this when it
+     // changes the current window global, but that happens before this and we
 diff --git a/dom/base/nsFocusManager.cpp b/dom/base/nsFocusManager.cpp
 index 7178d5a58a67..bda045d7ee16 100644
 --- a/dom/base/nsFocusManager.cpp
@@ -78,6 +106,18 @@ index b1e658a2dc87..a4c647ebd219 100644
  nsresult BrowserChild::GetHasSiblings(bool* aHasSiblings) {
    *aHasSiblings = mHasSiblings;
    return NS_OK;
+diff --git a/security/manager/ssl/nsSecureBrowserUI.cpp b/security/manager/ssl/nsSecureBrowserUI.cpp
+index fd9a26d42b79..3d4b5c75fb29 100644
+--- a/security/manager/ssl/nsSecureBrowserUI.cpp
++++ b/security/manager/ssl/nsSecureBrowserUI.cpp
+@@ -58,6 +58,7 @@ static bool GetWebProgressListener(CanonicalBrowsingContext* aBrowsingContext,
+   MOZ_ASSERT(aOutBrowser);
+   MOZ_ASSERT(aOutManager);
+   MOZ_ASSERT(aOutListener);
++  return true;
+ 
+   nsCOMPtr<nsIBrowser> browser;
+   RefPtr<Element> currentElement = aBrowsingContext->GetEmbedderElement();
 -- 
 2.31.1
 

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -131,7 +131,7 @@ Patch73:    0073-sailfishos-components-Cleanup-static-components-defi.patch
 Patch74:    0074-Revert-Bug-1611658-Unship-libcubeb-s-C-PulseAudio-ba.patch
 Patch75:    0075-sailfishos-gfx-Use-scroll-frame-background-color-as-.patch
 Patch76:    0076-sailfishos-gecko-Ignore-safemode-in-gfxPlatform.-Fix.patch
-Patch77:    0077-sailfishos-browserchild-Add-parentIsActive-attribute.patch
+Patch77:    0077-sailfishos-docshell-Align-fix-parentprocess-checks.-.patch
 Patch78:    0078-sailfishos-webrtc-Adapt-build-configuration-for-Sail.patch
 Patch79:    0079-sailfishos-webrtc-Regenerate-moz.build-files.-JB-537.patch
 Patch80:    0080-sailfishos-webrtc-Disable-desktop-sharing-feature-on.patch


### PR DESCRIPTION
Contains 3 commits:

1. First one makes it possible to use nsSecureBrowserUI and update it
when location is changed. Follow up commit will create nsSecureBrowserUI.
2. Fix crash in EmbedLiteSecurity
3. Create Secure Browser UI when gecko window created