### PR TITLE
[sailfishos][gecko] Fix download starting when multiple tabs are closed. JB#56047 OMP#JOLLA-476

### DIFF
--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -183,6 +183,9 @@ mozilla::ipc::IPCResult EmbedLiteViewChild::RecvDestroy()
   }
 
   EmbedLiteAppService::AppService()->UnregisterView(mId);
+  if (mWebBrowser) {
+    mWebBrowser->Destroy();
+  }
   if (mHelper)
     mHelper->Unload();
   if (mChrome)


### PR DESCRIPTION
When the active tab is closed another tab will be made active and start
to load, if that tab is closed while loading the parent puppet widget can be
destroyed before the content view is created causing a failure in the
content view construction the error from which gets interpreted as the
unsupported document type and the browser falls back to downloading.

There is a failure case for when this happens and the DocShell is in
destroyed state which cancels the loading the document, so we can do the
same if the puppet widget has been destroyed.