### PR TITLE
[sailfishos][gecko] Bump up to latest 78.15.1 sha1. Fixes JB#55681 OMP#JOLLA-402

### DIFF
--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -1,4 +1,4 @@
-%define greversion    78.11.0
+%define greversion    78.15.1
 %define milestone     %{greversion}
 
 %define embedlite_config merqtxulrunner


### PR DESCRIPTION
- No changes were needed for any patch which is kinda surprising
- Created test builds for i486 and arm
- Built qtmozembed, sailfish-components-webview, and sailfish-browser on top of this, quick smoke => it starts

Depending on in which order new changes land we may need to adjust this. Tried to cherry-pick changes from https://github.com/sailfishos/gecko-dev/pull/99 and at least that change applies nicely on top this as well.