### PR TITLE
[sailfishos][gecko-dev] Enable the pointer event API. JB#56149 OMP#JOLLA-499

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -1,6 +1,6 @@
 pref("dom.w3c_touch_events.enabled", 1);
 pref("dom.w3c_touch_events.legacy_apis.enabled", true);
-pref("dom.w3c_pointer_events.enabled", false);
+pref("dom.w3c_pointer_events.enabled", true);
 pref("dom.meta-viewport.enabled", true);
 pref("plugins.force.wmode", "opaque");
 pref("browser.xul.error_pages.enabled", true);

--- a/rpm/0084-sailfishos-gecko-dev-Disallow-page-zooming-if-the-me.patch
+++ b/rpm/0084-sailfishos-gecko-dev-Disallow-page-zooming-if-the-me.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew den Exter <andrew.den.exter@jolla.com>
+Date: Thu, 11 Nov 2021 06:51:59 +0000
+Subject: [PATCH] [sailfishos][gecko-dev] Disallow page zooming if the meta
+ viewport scale is fixed. JB#56149 OMP#JOLLA-49
+
+---
+ layout/base/nsLayoutUtils.cpp | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/layout/base/nsLayoutUtils.cpp b/layout/base/nsLayoutUtils.cpp
+index 2cd2903a8fc8..85e290c0d90f 100644
+--- a/layout/base/nsLayoutUtils.cpp
++++ b/layout/base/nsLayoutUtils.cpp
+@@ -694,13 +694,27 @@ bool nsLayoutUtils::AsyncPanZoomEnabled(nsIFrame* aFrame) {
+   return widget->AsyncPanZoomEnabled();
+ }
+ 
++
++static bool DocumentHasFixedUnityZoom(const mozilla::dom::Document* aDocument)
++{
++  if (!aDocument) {
++    return false;
++  }
++  nsresult rv;
++  ViewportMetaData metaData = aDocument->GetViewportMetaData();
++  return (!metaData.mMinimumScale.IsEmpty() && metaData.mMinimumScale == metaData.mMaximumScale) ||
++          metaData.mUserScalable.EqualsLiteral("0") ||
++          metaData.mUserScalable.EqualsLiteral("no") ||
++          metaData.mUserScalable.EqualsLiteral("false");
++}
++
+ bool nsLayoutUtils::AllowZoomingForDocument(
+     const mozilla::dom::Document* aDocument) {
+   // True if we allow zooming for all documents on this platform, or if we are
+   // in RDM and handling meta viewports, which force zoom under some
+   // circumstances.
+   BrowsingContext* bc = aDocument ? aDocument->GetBrowsingContext() : nullptr;
+-  return StaticPrefs::apz_allow_zooming() ||
++  return (StaticPrefs::apz_allow_zooming() && !DocumentHasFixedUnityZoom(aDocument)) ||
+          (bc && bc->InRDMPane() &&
+           nsLayoutUtils::ShouldHandleMetaViewport(aDocument));
+ }
+-- 
+2.26.2
+

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -138,6 +138,7 @@ Patch80:    0080-sailfishos-webrtc-Disable-desktop-sharing-feature-on.patch
 Patch81:    0081-sailfishos-webrtc-Enable-GMP-for-encoding-decoding.-.patch
 Patch82:    0082-sailfishos-webrtc-Implement-video-capture-module.-JB.patch
 Patch83:    0083-sailfishos-gecko-Allow-LoginManagerPrompter-to-find-.patch
+Patch84:    0084-sailfishos-gecko-dev-Disallow-page-zooming-if-the-me.patch
 #Patch20:    0020-sailfishos-loginmanager-Adapt-LoginManager-to-EmbedL.patch
 #Patch51:    0051-sailfishos-gecko-Remove-android-define-from-logging.patch
 #Patch59:    0059-sailfishos-gecko-Ignore-safemode-in-gfxPlatform.-Fix.patch


### PR DESCRIPTION
It was disabled because the APZ page zoom gets priority access to pinch
gestures which meant custom zooming using the pointer events didn't work
on some sites, but a fallback to legacy touch APIs did work if the
pointer API wasn't available did. Other sites have the inverse problem
where their fallback code paths have rotted and they don't work without
the pointer API.

The page zoom getting priority issue can be mitigated by disabling it if
the page sets both the meta viewport minimum and maximum scales to 1.