### PR TITLE
[sailfishos][embedlite] Make EmbedFrame an EventListener. JB#56094 OMP#JOLLA-492

### DIFF
--- a/embedding/embedlite/modules/EmbedFrame.cpp
+++ b/embedding/embedlite/modules/EmbedFrame.cpp
@@ -4,6 +4,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "EmbedFrame.h"
+#include "mozilla/dom/EmbedFrameBinding.h"
+
+namespace mozilla {
+namespace dom {
 
 EmbedFrame::EmbedFrame()
 {
@@ -13,20 +17,41 @@ EmbedFrame::~EmbedFrame()
 {
 }
 
-NS_IMPL_ISUPPORTS(EmbedFrame, nsIEmbedFrame)
+NS_IMPL_CYCLE_COLLECTION_CLASS(EmbedFrame)
 
-NS_IMETHODIMP
-EmbedFrame::GetContentWindow(nsIDOMWindow** aWindow)
+NS_IMPL_CYCLE_COLLECTION_UNLINK_BEGIN_INHERITED(EmbedFrame,
+                                                mozilla::DOMEventTargetHelper)
+NS_IMPL_CYCLE_COLLECTION_UNLINK_END
+
+NS_IMPL_CYCLE_COLLECTION_TRAVERSE_BEGIN_INHERITED(EmbedFrame,
+                                                  mozilla::DOMEventTargetHelper)
+NS_IMPL_CYCLE_COLLECTION_TRAVERSE_END
+
+NS_INTERFACE_MAP_BEGIN_CYCLE_COLLECTION(EmbedFrame)
+NS_INTERFACE_MAP_END_INHERITING(mozilla::DOMEventTargetHelper)
+
+NS_IMPL_ADDREF_INHERITED(EmbedFrame, mozilla::DOMEventTargetHelper)
+NS_IMPL_RELEASE_INHERITED(EmbedFrame, mozilla::DOMEventTargetHelper)
+
+Nullable<WindowProxyHolder> EmbedFrame::GetContentWindow()
 {
-  nsCOMPtr<nsIDOMWindow> window = mWindow;
-  window.forget(aWindow);
-  return NS_OK;
+  if (mWindow) {
+    return dom::WindowProxyHolder(mWindow);
+  } else {
+    return nullptr;
+  }
 }
 
-NS_IMETHODIMP
-EmbedFrame::GetMessageManager(ContentFrameMessageManager** aMessageManager)
+already_AddRefed<mozilla::dom::ContentFrameMessageManager> EmbedFrame::MessageManager()
 {
-  RefPtr<ContentFrameMessageManager> mm(mMessageManager);
-  mm.forget(aMessageManager);
-  return NS_OK;
+    RefPtr<mozilla::dom::ContentFrameMessageManager> mm = mMessageManager;
+    return mm.forget();
+};
+
+JSObject* EmbedFrame::WrapObject(JSContext* aCx,
+                                           JS::Handle<JSObject*> aGivenProto) {
+  return EmbedFrame_Binding::Wrap(aCx, this, aGivenProto);
+}
+
+}
 }

--- a/embedding/embedlite/modules/EmbedFrame.h
+++ b/embedding/embedlite/modules/EmbedFrame.h
@@ -6,23 +6,39 @@
 #ifndef EMBEDFRAME_H
 #define EMBEDFRAME_H
 
-#include "nsIEmbedFrame.h"
 #include "nsCOMPtr.h"
+#include "mozilla/DOMEventTargetHelper.h"
 #include "mozilla/dom/ContentFrameMessageManager.h"
+#include "mozilla/dom/BrowsingContext.h"
 
-class EmbedFrame : public nsIEmbedFrame
+namespace mozilla {
+namespace dom {
+
+// This mocks a tiny subset of MozBrowser from browser-custom-element.js
+class EmbedFrame : public mozilla::DOMEventTargetHelper
 {
 public:
   NS_DECL_ISUPPORTS
-  NS_DECL_NSIEMBEDFRAME
+  NS_DECL_CYCLE_COLLECTION_CLASS_INHERITED(EmbedFrame,
+                                           mozilla::DOMEventTargetHelper)
 
   EmbedFrame();
 
-  nsCOMPtr<nsIDOMWindow> mWindow;
+  Nullable<WindowProxyHolder> GetContentWindow();
+  already_AddRefed<mozilla::dom::ContentFrameMessageManager> MessageManager();
+
+  RefPtr<mozilla::dom::BrowsingContext> mWindow;
   RefPtr<mozilla::dom::ContentFrameMessageManager> mMessageManager;
+
+  JSObject* WrapObject(JSContext* aCx,
+                       JS::Handle<JSObject*> aGivenProto) override;
+
 
 private:
   virtual ~EmbedFrame();
 };
+
+}
+}
 
 #endif

--- a/embedding/embedlite/modules/EmbedFrame.webidl
+++ b/embedding/embedlite/modules/EmbedFrame.webidl
@@ -3,17 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "nsISupports.idl"
-#include "nsIDOMWindow.idl"
-#include "nsIMessageManager.idl"
 
-interface nsIDOMWindow;
-interface nsIContentFrameMessageManager;
-webidl ContentFrameMessageManager;
-
-[scriptable, uuid(48738828-adbe-4106-a453-0d6e0965d6f8)]
-interface nsIEmbedFrame : nsISupports
-{
-  readonly attribute nsIDOMWindow contentWindow;
+[ChromeOnly, Exposed=(Window)]
+interface EmbedFrame : EventTarget {
+  readonly attribute WindowProxy? contentWindow;
   readonly attribute ContentFrameMessageManager messageManager;
 };

--- a/embedding/embedlite/moz.build
+++ b/embedding/embedlite/moz.build
@@ -19,12 +19,15 @@ FINAL_LIBRARY = 'xul'
 XPIDL_SOURCES += [
     'embedshared/EmbedLiteViewIface.idl',
     'modules/nsIEmbedAppService.idl',
-    'modules/nsIEmbedFrame.idl',
     'modules/nsIEmbedLiteJSON.idl',
     'utils/nsIEmbedBrowserChromeListener.idl',
 ]
 
 XPIDL_MODULE = 'embedLite'
+
+WEBIDL_FILES = [
+    'modules/EmbedFrame.webidl',
+]
 
 EXPORTS.mozilla.embedlite += [
     'EmbedInputData.h',
@@ -52,6 +55,10 @@ EXPORTS.mozilla.embedlite += [
     'utils/EmbedLiteXulAppInfo.h',
     'utils/EmbedLog.h',
     'utils/WebBrowserChrome.h',
+]
+
+EXPORTS.mozilla.dom += [
+    'modules/EmbedFrame.h',
 ]
 
 EXPORTS.ipc = ['embedhelpers/EmbedIPCUtils.h']


### PR DESCRIPTION
A message handler in RemotePageHandler was failing because it attempted
to install an event handler on the target of the received message but
addEventListener wasn't a didn't exist on EmbedFrame. The equivalent
object in Firefox appears to MozBrowser which is a javascript defined
object so there isn't a direct translation, but similarly structured
interfaces appear to be defined in webidl and extend EventTarget.