### PR TITLE
[sailfishos][embedlite] Enable VisualViewport API. JB#56066 OMP#JOLLA-479

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -453,3 +453,6 @@ pref("media.webrtc.hw.h264.enabled", true);
 // the gecko skips the peer's preference and creates an h264 decoder. As a workaround, disable VP9
 // until the bug is fixed.
 pref("media.peerconnection.video.vp9_enabled", false);
+
+// Enable the Visual Viewport API
+pref("dom.visualviewport.enabled", true);


### PR DESCRIPTION
Once enabled from window.visualViewport we can for instance get visual
viewport offset from the top-left corner.