### PR TITLE
[sailfishos][embedlite] Prevent invalid manifest location from being added. Fixes JB#56395

### DIFF
--- a/embedding/embedlite/EmbedLiteApp.cpp
+++ b/embedding/embedlite/EmbedLiteApp.cpp
@@ -275,7 +275,12 @@ EmbedLiteApp::StartChildThread()
     nsCOMPtr<nsIFile> f;
     NS_NewNativeLocalFile(sComponentDirs[i], true,
                           getter_AddRefs(f));
-    XRE_AddManifestLocation(NS_APP_LOCATION, f);
+    if (f) {
+      LOGT("Loading manifest: %s", sComponentDirs[i].get());
+      XRE_AddManifestLocation(NS_APP_LOCATION, f);
+    } else {
+      NS_ERROR(nsPrintfCString("Failed to create nsIFile for manifest location: %s", sComponentDirs[i].get()).get());
+    }
   }
 
   GeckoLoader::InitEmbedding(mProfilePath);

--- a/embedding/embedlite/embedshared/EmbedLiteAppChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteAppChild.cpp
@@ -291,7 +291,7 @@ mozilla::ipc::IPCResult EmbedLiteAppChild::RecvLoadComponentManifest(const nsCSt
     LOGT("Loading manifest: %s", manifest.get());
     XRE_AddManifestLocation(NS_APP_LOCATION, f);
   } else {
-    NS_ERROR("Failed to create nsIFile for manifest location");
+    NS_ERROR(nsPrintfCString("Failed to create nsIFile for manifest location: %s", manifest.get()).get());
   }
   return IPC_OK();
 }


### PR DESCRIPTION
Cherry-picking https://github.com/sailfishos/gecko-dev/pull/110 to the master.