### PR TITLE
[sailfishos][embedlite] Http max-connections to 40. Fixes JB#56477 OMP#JOLLA-555

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -180,7 +180,7 @@ pref("network.protocol-handler.warn-external.vnd.youtube", false);
 
 /* http prefs */
 pref("network.http.keep-alive.timeout", 109);
-pref("network.http.max-connections", 20);
+pref("network.http.max-connections", 40);
 pref("network.http.max-persistent-connections-per-server", 6);
 pref("network.http.max-persistent-connections-per-proxy", 20);
 


### PR DESCRIPTION
See https://github.com/sailfishos-mirror/gecko-dev/blob/esr78/modules/libpref/init/all.js#L1352