### PR TITLE
[sailfishos][embedlite] Drop root frame argument from the PEmbedLiteView.ipdl and EmbedLiteViewListener::HandleScrollEvent. JB#56312 OMP#JOLLA-530

### DIFF
--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -53,8 +53,10 @@ public:
   virtual void OnWindowCloseRequested(void) {}
   virtual void OnHttpUserAgentUsed(const char16_t* aHttpUserAgent) {}
 
-  virtual bool HandleScrollEvent(bool aIsRootScrollFrame, const gfxRect& aContentRect,
-                                 const gfxSize& aScrollableSize) { return false; }
+  virtual bool HandleScrollEvent(const gfxRect& aContentRect, const gfxSize& aScrollableSize)
+  {
+    return false;
+  }
 
   virtual void IMENotification(int aEnabled, bool aOpen, int aCause, int aFocusChange, const char16_t* inputType, const char16_t* inputMode) {}
   virtual void GetIMEStatus(int32_t* aIMEEnabled, int32_t* aIMEOpen) {}

--- a/embedding/embedlite/PEmbedLiteView.ipdl
+++ b/embedding/embedlite/PEmbedLiteView.ipdl
@@ -58,7 +58,7 @@ child:
     async SetHttpUserAgent(nsString aHttpUserAgent);
     async SuspendTimeouts();
     async ResumeTimeouts();
-    async HandleScrollEvent(bool isRootScrollFrame, gfxRect contentRect, gfxSize scrollSize);
+    async HandleScrollEvent(gfxRect contentRect, gfxSize scrollSize);
 
     async UpdateFrame(RepaintRequest request) compress;
     async HandleDoubleTap(LayoutDevicePoint aPoint, Modifiers aModifiers, ScrollableLayerGuid aGuid, uint64_t aInputBlockId);

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -918,8 +918,7 @@ mozilla::ipc::IPCResult EmbedLiteViewChild::RecvRemoveMessageListeners(nsTArray<
   return IPC_OK();
 }
 
-mozilla::ipc::IPCResult EmbedLiteViewChild::RecvHandleScrollEvent(const bool &isRootScrollFrame,
-                                                                  const gfxRect &contentRect,
+mozilla::ipc::IPCResult EmbedLiteViewChild::RecvHandleScrollEvent(const gfxRect &contentRect,
                                                                   const gfxSize &scrollSize)
 {
   mozilla::CSSRect rect(contentRect.x, contentRect.y, contentRect.width, contentRect.height);

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.h
@@ -153,8 +153,7 @@ protected:
   virtual mozilla::ipc::IPCResult RecvSuspendTimeouts();
   virtual mozilla::ipc::IPCResult RecvResumeTimeouts();
   virtual mozilla::ipc::IPCResult RecvLoadFrameScript(const nsString &);
-  virtual mozilla::ipc::IPCResult RecvHandleScrollEvent(const bool &isRootScrollFrame,
-                                                        const gfxRect &contentRect,
+  virtual mozilla::ipc::IPCResult RecvHandleScrollEvent(const gfxRect &contentRect,
                                                         const gfxSize &scrollSize);
 
   virtual mozilla::ipc::IPCResult RecvUpdateFrame(const mozilla::layers::RepaintRequest &aRequest);

--- a/embedding/embedlite/embedthread/EmbedContentController.cpp
+++ b/embedding/embedlite/embedthread/EmbedContentController.cpp
@@ -177,8 +177,8 @@ void EmbedContentController::DoSendScrollEvent(const layers::RepaintRequest aReq
   gfxRect rect(contentRect.x, contentRect.y, contentRect.width, contentRect.height);
   gfxSize size(scrollableSize.width, scrollableSize.height);
 
-  if (mRenderFrame && !GetListener()->HandleScrollEvent(aRequest.IsRootContent(), rect, size)) {
-    Unused << mRenderFrame->SendHandleScrollEvent(aRequest.IsRootContent(), rect, size);
+  if (mRenderFrame && !GetListener()->HandleScrollEvent(rect, size)) {
+    Unused << mRenderFrame->SendHandleScrollEvent(rect, size);
   }
 }
 


### PR DESCRIPTION
In order to dig out the root scrollable rect from the LayerManager,
let's drop unused root frame argument as it is unused.