### PR TITLE
[sailfishos][rpm] Re-enable startup cache for all arch except x86. Fixes JB#55488 OMP#JOLLA-374

### DIFF
--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -423,12 +423,10 @@ echo "ac_add_options --host=i686-unknown-linux-gnu" >> "$MOZCONFIG"
 %endif
 
 %ifarch %arm32
-echo "ac_add_options --disable-startupcache" >> "$MOZCONFIG"
 echo "ac_add_options --host=armv7-unknown-linux-gnueabihf" >> "$MOZCONFIG"
 %endif
 
 %ifarch %arm64
-echo "ac_add_options --disable-startupcache" >> "$MOZCONFIG"
 echo "ac_add_options --host=aarch64-unknown-linux-gnu" >> "$MOZCONFIG"
 %endif
 


### PR DESCRIPTION
This commit effectively reverts sha1 bd5f5923ce6662c8bf8b3c4337