### PR TITLE
Fix egl patch to prevent crashing. Fixes JB#56606 OMP#JOLLA-565

### DIFF
--- a/rpm/0038-sailfishos-embedlite-egl-Fix-mesa-egl-display-and-bu.patch
+++ b/rpm/0038-sailfishos-embedlite-egl-Fix-mesa-egl-display-and-bu.patch
@@ -22,7 +22,7 @@ Contributing authors:
  4 files changed, 225 insertions(+), 31 deletions(-)
 
 diff --git a/gfx/gl/GLContextProviderEGL.cpp b/gfx/gl/GLContextProviderEGL.cpp
-index dc0714a84351..3f1089e28bd5 100644
+index dc0714a84351..88f141eae912 100644
 --- a/gfx/gl/GLContextProviderEGL.cpp
 +++ b/gfx/gl/GLContextProviderEGL.cpp
 @@ -77,6 +77,14 @@
@@ -70,7 +70,7 @@ index dc0714a84351..3f1089e28bd5 100644
 +#define WL_SURFACE_DESTROY 0
 +
 +// Used for lifetime management of the dynamically loaded wayland libraries
-+static bool wayloadFunctionsLoaded = false;
++static bool waylandFunctionsLoaded = false;
 +static void *waylandEglHandle = nullptr;
 +static void *waylandClientHandle = nullptr;
 +
@@ -103,7 +103,7 @@ index dc0714a84351..3f1089e28bd5 100644
 +}
 +
 +static bool LoadWaylandFunctions() {
-+  if (wayloadFunctionsLoaded) {
++  if (waylandFunctionsLoaded) {
 +    // We load everything or nothing
 +    return true;
 +  }
@@ -149,15 +149,15 @@ index dc0714a84351..3f1089e28bd5 100644
 +    return false;
 +  }
 +
-+  wayloadFunctionsLoaded = true;
++  waylandFunctionsLoaded = true;
 +  return true;
 +}
 +
-+static bool UnloadWaylandFunctions() {
-+  if (wayloadFunctionsLoaded) {
++static void UnloadWaylandFunctions() {
++  if (waylandFunctionsLoaded) {
 +    dlclose(waylandEglHandle);
 +    dlclose(waylandClientHandle);
-+    wayloadFunctionsLoaded = false;
++    waylandFunctionsLoaded = false;
 +  }
 +}
 +#endif


### PR DESCRIPTION
A static function in the code had return value `bool`, but no return statement. The compiler then optimised this undefined behaviour into a crash (calling an otherwise guarded `dlopen` with an invalid parameter).

This change removes the crash by setting the return as void. Now the `dlopen` is only called when it's supposed to be.

Thanks to @Tomin1 and especially @spiiroin for noticing the incorrect code.

This change also fixes up an incorrectly named variable.