### PR TITLE
Pass parent browsing context down to CreateNewWindowRequested

### DIFF
--- a/embedding/embedlite/EmbedLiteApp.cpp
+++ b/embedding/embedlite/EmbedLiteApp.cpp
@@ -525,7 +525,8 @@ EmbedLiteApp::ChildReadyToDestroy()
 }
 
 uint32_t
-EmbedLiteApp::CreateWindowRequested(const uint32_t& chromeFlags, const uint32_t& parentId)
+EmbedLiteApp::CreateWindowRequested(const uint32_t &chromeFlags,
+                                    const uint32_t &parentId)
 {
   EmbedLiteView* view = nullptr;
   std::map<uint32_t, EmbedLiteView*>::iterator it;

--- a/embedding/embedlite/EmbedLiteApp.cpp
+++ b/embedding/embedlite/EmbedLiteApp.cpp
@@ -468,7 +468,7 @@ void EmbedLiteApp::RemoveObservers(const std::vector<std::string>& observersList
 }
 
 EmbedLiteView*
-EmbedLiteApp::CreateView(EmbedLiteWindow* aWindow, uint32_t aParent, bool aIsPrivateWindow, bool isDesktopMode)
+EmbedLiteApp::CreateView(EmbedLiteWindow* aWindow, uint32_t aParent, uintptr_t aParentBrowsingContext, bool aIsPrivateWindow, bool isDesktopMode)
 {
   LOGT();
   NS_ASSERTION(mState == INITIALIZED, "The app must be up and runnning by now");
@@ -477,7 +477,7 @@ EmbedLiteApp::CreateView(EmbedLiteWindow* aWindow, uint32_t aParent, bool aIsPri
 
   PEmbedLiteViewParent* viewParent = static_cast<PEmbedLiteViewParent*>(
       mAppParent->SendPEmbedLiteViewConstructor(aWindow->GetUniqueID(), sViewCreateID,
-                                                aParent, aIsPrivateWindow, isDesktopMode));
+                                                aParent, aParentBrowsingContext, aIsPrivateWindow, isDesktopMode));
   EmbedLiteView* view = new EmbedLiteView(this, aWindow, viewParent, sViewCreateID);
   mViews[sViewCreateID] = view;
   return view;
@@ -526,7 +526,8 @@ EmbedLiteApp::ChildReadyToDestroy()
 
 uint32_t
 EmbedLiteApp::CreateWindowRequested(const uint32_t &chromeFlags,
-                                    const uint32_t &parentId)
+                                    const uint32_t &parentId,
+                                    const uintptr_t &parentBrowsingContext)
 {
   EmbedLiteView* view = nullptr;
   std::map<uint32_t, EmbedLiteView*>::iterator it;
@@ -537,7 +538,7 @@ EmbedLiteApp::CreateWindowRequested(const uint32_t &chromeFlags,
       break;
     }
   }
-  uint32_t viewId = mListener ? mListener->CreateNewWindowRequested(chromeFlags, view) : 0;
+  uint32_t viewId = mListener ? mListener->CreateNewWindowRequested(chromeFlags, view, parentBrowsingContext) : 0;
   return viewId;
 }
 

--- a/embedding/embedlite/EmbedLiteApp.h
+++ b/embedding/embedlite/EmbedLiteApp.h
@@ -50,8 +50,8 @@ public:
   // Messaging interface, allow to receive json messages from content child scripts
   virtual void OnObserve(const char* aMessage, const char16_t* aData) {}
   // New Window request which is usually coming from WebPage new window request
-  virtual uint32_t CreateNewWindowRequested(const uint32_t& chromeFlags,
-                                            EmbedLiteView* aParentView) { return 0; }
+  virtual uint32_t CreateNewWindowRequested(const uint32_t &chromeFlags,
+                                            EmbedLiteView *aParentView) { return 0; }
   virtual void LastViewDestroyed() {};
   virtual void LastWindowDestroyed() {};
 };
@@ -189,7 +189,8 @@ private:
   void ViewDestroyed(uint32_t id);
   void WindowDestroyed(uint32_t id);
   void ChildReadyToDestroy();
-  uint32_t CreateWindowRequested(const uint32_t& chromeFlags, const uint32_t& parentId);
+  uint32_t CreateWindowRequested(const uint32_t &chromeFlags,
+                                 const uint32_t &parentId);
   EmbedLiteAppListener* GetListener();
   MessageLoop* GetUILoop();
   static void PreDestroy(EmbedLiteApp*);

--- a/embedding/embedlite/EmbedLiteApp.h
+++ b/embedding/embedlite/EmbedLiteApp.h
@@ -51,7 +51,8 @@ public:
   virtual void OnObserve(const char* aMessage, const char16_t* aData) {}
   // New Window request which is usually coming from WebPage new window request
   virtual uint32_t CreateNewWindowRequested(const uint32_t &chromeFlags,
-                                            EmbedLiteView *aParentView) { return 0; }
+                                            EmbedLiteView *aParentView,
+                                            const uintptr_t &parentBrowsingContext) { return 0; }
   virtual void LastViewDestroyed() {};
   virtual void LastWindowDestroyed() {};
 };
@@ -111,7 +112,11 @@ public:
   // Must be called from same thread as StartChildThread, and before Stop()
   virtual bool StopChildThread();
 
-  virtual EmbedLiteView* CreateView(EmbedLiteWindow* aWindow, uint32_t aParent = 0, bool aIsPrivateWindow = false, bool isDesktopMode = false);
+  virtual EmbedLiteView* CreateView(EmbedLiteWindow* aWindow,
+                                    uint32_t aParent = 0,
+                                    uintptr_t parentBrowsingContext = 0,
+                                    bool aIsPrivateWindow = false,
+                                    bool isDesktopMode = false);
   virtual EmbedLiteWindow* CreateWindow(int width, int height, EmbedLiteWindowListener *aListener = nullptr);
   virtual EmbedLiteSecurity* CreateSecurity(const char *aStatus, unsigned int aState) const;
   virtual void DestroyView(EmbedLiteView* aView);
@@ -190,7 +195,8 @@ private:
   void WindowDestroyed(uint32_t id);
   void ChildReadyToDestroy();
   uint32_t CreateWindowRequested(const uint32_t &chromeFlags,
-                                 const uint32_t &parentId);
+                                 const uint32_t &parentId,
+                                 const uintptr_t &parentBrowsingContext);
   EmbedLiteAppListener* GetListener();
   MessageLoop* GetUILoop();
   static void PreDestroy(EmbedLiteApp*);

--- a/embedding/embedlite/PEmbedLiteApp.ipdl
+++ b/embedding/embedlite/PEmbedLiteApp.ipdl
@@ -18,12 +18,12 @@ nested(upto inside_cpow) sync protocol PEmbedLiteApp {
 parent:
   async Initialized();
   async ReadyToShutdown();
-  sync CreateWindow(uint32_t parentId, uint32_t chromeFlags)
+  sync CreateWindow(uint32_t parentId, uintptr_t parentBrowsingContext, uint32_t chromeFlags)
     returns (uint32_t createdID, bool cancel);
   async PrefsArrayInitialized(Pref[] prefs);
 
 child:
-  async PEmbedLiteView(uint32_t windowId, uint32_t id, uint32_t parentId, bool isPrivateWindow, bool isDesktopMode);
+  async PEmbedLiteView(uint32_t windowId, uint32_t id, uint32_t parentId, uintptr_t parentBrowsingContext, bool isPrivateWindow, bool isDesktopMode);
   async PEmbedLiteWindow(uint16_t width, uint16_t height, uint32_t id, uintptr_t listener);
   async PreDestroy();
   async SetBoolPref(nsCString name, bool value);

--- a/embedding/embedlite/embedprocess/EmbedLiteAppProcessChild.cpp
+++ b/embedding/embedlite/embedprocess/EmbedLiteAppProcessChild.cpp
@@ -34,6 +34,7 @@
 #include "mozilla/layers/PCompositorBridgeChild.h"
 
 #include "mozilla/Preferences.h"
+#include "mozilla/dom/BrowsingContext.h"
 #include "mozilla/dom/PContent.h"
 
 using namespace base;
@@ -175,6 +176,7 @@ PEmbedLiteViewChild*
 EmbedLiteAppProcessChild::AllocPEmbedLiteViewChild(const uint32_t &windowId,
                                                    const uint32_t &id,
                                                    const uint32_t &parentId,
+                                                   const uintptr_t &parentBrowsingContext,
                                                    const bool &isPrivateWindow,
                                                    const bool &isDesktopMode)
 {
@@ -184,7 +186,16 @@ EmbedLiteAppProcessChild::AllocPEmbedLiteViewChild(const uint32_t &windowId,
     gfxPlatform::GetPlatform();
     sViewInitializeOnce = true;
   }
-  EmbedLiteViewProcessChild* view = new EmbedLiteViewProcessChild(windowId, id, parentId, isPrivateWindow, isDesktopMode);
+
+
+  mozilla::dom::BrowsingContext *parentBrowsingContextPtr = nullptr;
+  if (parentBrowsingContext) {
+    parentBrowsingContextPtr = reinterpret_cast<mozilla::dom::BrowsingContext*>(parentBrowsingContext);
+  }
+
+  EmbedLiteViewProcessChild* view = new EmbedLiteViewProcessChild(windowId, id, parentId,
+                                                                  parentBrowsingContextPtr,
+                                                                  isPrivateWindow, isDesktopMode);
   view->AddRef();
   return view;
 }

--- a/embedding/embedlite/embedprocess/EmbedLiteAppProcessChild.cpp
+++ b/embedding/embedlite/embedprocess/EmbedLiteAppProcessChild.cpp
@@ -172,9 +172,11 @@ EmbedLiteAppProcessChild::QuickExit()
 }
 
 PEmbedLiteViewChild*
-EmbedLiteAppProcessChild::AllocPEmbedLiteViewChild(const uint32_t& windowId, const uint32_t& id,
-                                                   const uint32_t& parentId, const bool& isPrivateWindow,
-                                                   const bool& isDesktopMode)
+EmbedLiteAppProcessChild::AllocPEmbedLiteViewChild(const uint32_t &windowId,
+                                                   const uint32_t &id,
+                                                   const uint32_t &parentId,
+                                                   const bool &isPrivateWindow,
+                                                   const bool &isDesktopMode)
 {
   LOGT("id:%u, parentId:%u", id, parentId);
   static bool sViewInitializeOnce = false;

--- a/embedding/embedlite/embedprocess/EmbedLiteAppProcessChild.h
+++ b/embedding/embedlite/embedprocess/EmbedLiteAppProcessChild.h
@@ -42,6 +42,7 @@ protected:
   virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t &windowId,
                                                         const uint32_t &id,
                                                         const uint32_t &parentId,
+                                                        const uintptr_t &parentBrowsingContext,
                                                         const bool &isPrivateWindow,
                                                         const bool &isDesktopMode) override;
 

--- a/embedding/embedlite/embedprocess/EmbedLiteAppProcessChild.h
+++ b/embedding/embedlite/embedprocess/EmbedLiteAppProcessChild.h
@@ -39,11 +39,11 @@ public:
   }
 
 protected:
-  virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t& windowId,
-                                                        const uint32_t& id,
-                                                        const uint32_t& parentId,
-                                                        const bool& isPrivateWindow,
-                                                        const bool& isDesktopMode) override;
+  virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t &windowId,
+                                                        const uint32_t &id,
+                                                        const uint32_t &parentId,
+                                                        const bool &isPrivateWindow,
+                                                        const bool &isDesktopMode) override;
 
   virtual PEmbedLiteWindowChild* AllocPEmbedLiteWindowChild(const uint16_t &width, const uint16_t &height,
                                                             const uint32_t &id, const uintptr_t &aListener) override;

--- a/embedding/embedlite/embedprocess/EmbedLiteAppProcessParent.cpp
+++ b/embedding/embedlite/embedprocess/EmbedLiteAppProcessParent.cpp
@@ -213,12 +213,13 @@ EmbedLiteAppProcessParent::RecvReadyToShutdown()
 
 mozilla::ipc::IPCResult
 EmbedLiteAppProcessParent::RecvCreateWindow(const uint32_t &parentId,
+                                            const uintptr_t &parentBrowsingContext,
                                             const uint32_t &chromeFlags,
                                             uint32_t *createdID,
                                             bool *cancel)
 {
   LOGT();
-  *createdID = mApp->CreateWindowRequested(chromeFlags, parentId);
+  *createdID = mApp->CreateWindowRequested(chromeFlags, parentId, parentBrowsingContext);
   *cancel = !*createdID;
   return IPC_OK();
 }
@@ -234,6 +235,7 @@ PEmbedLiteViewParent*
 EmbedLiteAppProcessParent::AllocPEmbedLiteViewParent(const uint32_t &windowId,
                                                      const uint32_t &id,
                                                      const uint32_t &parentId,
+                                                     const uintptr_t &parentBrowsingContext,
                                                      const bool &isPrivateWindow,
                                                      const bool &isDesktopMode)
 {
@@ -245,7 +247,7 @@ EmbedLiteAppProcessParent::AllocPEmbedLiteViewParent(const uint32_t &windowId,
     mozilla::layers::CompositorThreadHolder::Start();
   }
 
-  EmbedLiteViewProcessParent* p = new EmbedLiteViewProcessParent(windowId, id, parentId, isPrivateWindow, isDesktopMode);
+  EmbedLiteViewProcessParent* p = new EmbedLiteViewProcessParent(windowId, id, parentId, parentBrowsingContext, isPrivateWindow, isDesktopMode);
   p->AddRef();
   return p;
 }

--- a/embedding/embedlite/embedprocess/EmbedLiteAppProcessParent.cpp
+++ b/embedding/embedlite/embedprocess/EmbedLiteAppProcessParent.cpp
@@ -212,10 +212,10 @@ EmbedLiteAppProcessParent::RecvReadyToShutdown()
 }
 
 mozilla::ipc::IPCResult
-EmbedLiteAppProcessParent::RecvCreateWindow(const uint32_t& parentId,
-                                            const uint32_t& chromeFlags,
-                                            uint32_t* createdID,
-                                            bool* cancel)
+EmbedLiteAppProcessParent::RecvCreateWindow(const uint32_t &parentId,
+                                            const uint32_t &chromeFlags,
+                                            uint32_t *createdID,
+                                            bool *cancel)
 {
   LOGT();
   *createdID = mApp->CreateWindowRequested(chromeFlags, parentId);
@@ -231,11 +231,11 @@ EmbedLiteAppProcessParent::RecvObserve(const nsCString& topic, const nsString& d
 }
 
 PEmbedLiteViewParent*
-EmbedLiteAppProcessParent::AllocPEmbedLiteViewParent(const uint32_t& windowId,
-                                                     const uint32_t& id,
-                                                     const uint32_t& parentId,
-                                                     const bool& isPrivateWindow,
-                                                     const bool& isDesktopMode)
+EmbedLiteAppProcessParent::AllocPEmbedLiteViewParent(const uint32_t &windowId,
+                                                     const uint32_t &id,
+                                                     const uint32_t &parentId,
+                                                     const bool &isPrivateWindow,
+                                                     const bool &isDesktopMode)
 {
   LOGT();
 

--- a/embedding/embedlite/embedprocess/EmbedLiteAppProcessParent.h
+++ b/embedding/embedlite/embedprocess/EmbedLiteAppProcessParent.h
@@ -42,7 +42,11 @@ protected:
   virtual mozilla::ipc::IPCResult RecvObserve(const nsCString &topic,
                                               const nsString &data) override;
 
-  virtual PEmbedLiteViewParent *AllocPEmbedLiteViewParent(const uint32_t &windowId, const uint32_t &id, const uint32_t &parentId, const bool&, const bool&) override;
+  virtual PEmbedLiteViewParent *AllocPEmbedLiteViewParent(const uint32_t &windowId,
+                                                          const uint32_t &id,
+                                                          const uint32_t &parentId,
+                                                          const bool &isPrivateWindow,
+                                                          const bool &isDesktopMode) override;
 
   virtual bool DeallocPEmbedLiteViewParent(PEmbedLiteViewParent *aActor) override;
   virtual PEmbedLiteWindowParent *AllocPEmbedLiteWindowParent(const uint16_t &width, const uint16_t &height, const uint32_t &id, const uintptr_t &aListener) override;

--- a/embedding/embedlite/embedprocess/EmbedLiteAppProcessParent.h
+++ b/embedding/embedlite/embedprocess/EmbedLiteAppProcessParent.h
@@ -36,6 +36,7 @@ protected:
   virtual mozilla::ipc::IPCResult RecvInitialized() override;
   virtual mozilla::ipc::IPCResult RecvReadyToShutdown() override;
   virtual mozilla::ipc::IPCResult RecvCreateWindow(const uint32_t &parentId,
+                                                   const uintptr_t &parentBrowsingContext,
                                                    const uint32_t &chromeFlags,
                                                    uint32_t *createdID,
                                                    bool *cancel) override;
@@ -45,6 +46,7 @@ protected:
   virtual PEmbedLiteViewParent *AllocPEmbedLiteViewParent(const uint32_t &windowId,
                                                           const uint32_t &id,
                                                           const uint32_t &parentId,
+                                                          const uintptr_t &parentBrowsingContext,
                                                           const bool &isPrivateWindow,
                                                           const bool &isDesktopMode) override;
 

--- a/embedding/embedlite/embedprocess/EmbedLiteViewProcessChild.cpp
+++ b/embedding/embedlite/embedprocess/EmbedLiteViewProcessChild.cpp
@@ -9,11 +9,11 @@ namespace mozilla {
 namespace embedlite {
 
 MOZ_IMPLICIT
-EmbedLiteViewProcessChild::EmbedLiteViewProcessChild(const uint32_t& windowId,
-                                                     const uint32_t& id,
-                                                     const uint32_t& parentId,
-                                                     const bool& isPrivateWindow,
-                                                     const bool& isDesktopMode)
+EmbedLiteViewProcessChild::EmbedLiteViewProcessChild(const uint32_t &windowId,
+                                                     const uint32_t &id,
+                                                     const uint32_t &parentId,
+                                                     const bool &isPrivateWindow,
+                                                     const bool &isDesktopMode)
   : EmbedLiteViewChild(windowId, id, parentId, isPrivateWindow, isDesktopMode)
 {
   LOGT();

--- a/embedding/embedlite/embedprocess/EmbedLiteViewProcessChild.cpp
+++ b/embedding/embedlite/embedprocess/EmbedLiteViewProcessChild.cpp
@@ -1,5 +1,6 @@
 
 #include "EmbedLiteViewProcessChild.h"
+#include "mozilla/dom/BrowsingContext.h"
 #include "mozilla/layers/ShadowLayers.h"
 #include "mozilla/layers/ImageBridgeChild.h"
 
@@ -12,9 +13,10 @@ MOZ_IMPLICIT
 EmbedLiteViewProcessChild::EmbedLiteViewProcessChild(const uint32_t &windowId,
                                                      const uint32_t &id,
                                                      const uint32_t &parentId,
+                                                     mozilla::dom::BrowsingContext *parentBrowsingContext,
                                                      const bool &isPrivateWindow,
                                                      const bool &isDesktopMode)
-  : EmbedLiteViewChild(windowId, id, parentId, isPrivateWindow, isDesktopMode)
+  : EmbedLiteViewChild(windowId, id, parentId, parentBrowsingContext, isPrivateWindow, isDesktopMode)
 {
   LOGT();
 }

--- a/embedding/embedlite/embedprocess/EmbedLiteViewProcessChild.h
+++ b/embedding/embedlite/embedprocess/EmbedLiteViewProcessChild.h
@@ -9,6 +9,10 @@
 #include "EmbedLiteViewChild.h"
 
 namespace mozilla {
+namespace dom {
+class BrowsingContext;
+}
+
 namespace embedlite {
 
 class EmbedLiteViewProcessChild : public EmbedLiteViewChild
@@ -17,6 +21,7 @@ public:
   MOZ_IMPLICIT EmbedLiteViewProcessChild(const uint32_t &windowId,
                                          const uint32_t &id,
                                          const uint32_t &parentId,
+                                         mozilla::dom::BrowsingContext *parentBrowsingContext,
                                          const bool &isPrivateWindow,
                                          const bool &isDesktopMode);
 

--- a/embedding/embedlite/embedprocess/EmbedLiteViewProcessChild.h
+++ b/embedding/embedlite/embedprocess/EmbedLiteViewProcessChild.h
@@ -14,11 +14,11 @@ namespace embedlite {
 class EmbedLiteViewProcessChild : public EmbedLiteViewChild
 {
 public:
-  MOZ_IMPLICIT EmbedLiteViewProcessChild(const uint32_t& windowId,
-                                         const uint32_t& id,
-                                         const uint32_t& parentId,
-                                         const bool& isPrivateWindow,
-                                         const bool& isDesktopMode);
+  MOZ_IMPLICIT EmbedLiteViewProcessChild(const uint32_t &windowId,
+                                         const uint32_t &id,
+                                         const uint32_t &parentId,
+                                         const bool &isPrivateWindow,
+                                         const bool &isDesktopMode);
 
 protected:
   virtual void OnGeckoWindowInitialized();

--- a/embedding/embedlite/embedprocess/EmbedLiteViewProcessParent.cpp
+++ b/embedding/embedlite/embedprocess/EmbedLiteViewProcessParent.cpp
@@ -8,9 +8,10 @@ namespace embedlite {
 MOZ_IMPLICIT EmbedLiteViewProcessParent::EmbedLiteViewProcessParent(const uint32_t &windowId,
                                                                     const uint32_t &id,
                                                                     const uint32_t &parentId,
+                                                                    const uintptr_t &parentBrowsingContext,
                                                                     const bool &isPrivateWindow,
                                                                     const bool &isDesktopMode)
-  : EmbedLiteViewParent(windowId, id, parentId, isPrivateWindow, isDesktopMode)
+  : EmbedLiteViewParent(windowId, id, parentId, parentBrowsingContext, isPrivateWindow, isDesktopMode)
 {
     LOGT();
 }

--- a/embedding/embedlite/embedprocess/EmbedLiteViewProcessParent.cpp
+++ b/embedding/embedlite/embedprocess/EmbedLiteViewProcessParent.cpp
@@ -5,11 +5,11 @@
 namespace mozilla {
 namespace embedlite {
 
-MOZ_IMPLICIT EmbedLiteViewProcessParent::EmbedLiteViewProcessParent(const uint32_t& windowId,
-                                                                    const uint32_t& id,
-                                                                    const uint32_t& parentId,
-                                                                    const bool& isPrivateWindow,
-                                                                    const bool& isDesktopMode)
+MOZ_IMPLICIT EmbedLiteViewProcessParent::EmbedLiteViewProcessParent(const uint32_t &windowId,
+                                                                    const uint32_t &id,
+                                                                    const uint32_t &parentId,
+                                                                    const bool &isPrivateWindow,
+                                                                    const bool &isDesktopMode)
   : EmbedLiteViewParent(windowId, id, parentId, isPrivateWindow, isDesktopMode)
 {
     LOGT();

--- a/embedding/embedlite/embedprocess/EmbedLiteViewProcessParent.h
+++ b/embedding/embedlite/embedprocess/EmbedLiteViewProcessParent.h
@@ -15,11 +15,11 @@ namespace embedlite {
 class EmbedLiteViewProcessParent : public EmbedLiteViewParent
 {
 public:
-    MOZ_IMPLICIT EmbedLiteViewProcessParent(const uint32_t& windowId,
-                                            const uint32_t& id,
-                                            const uint32_t& parentId,
-                                            const bool& isPrivateWindow,
-                                            const bool& isDesktopMode);
+    MOZ_IMPLICIT EmbedLiteViewProcessParent(const uint32_t &windowId,
+                                            const uint32_t &id,
+                                            const uint32_t &parentId,
+                                            const bool &isPrivateWindow,
+                                            const bool &isDesktopMode);
     virtual ~EmbedLiteViewProcessParent() override;
 
 private:

--- a/embedding/embedlite/embedprocess/EmbedLiteViewProcessParent.h
+++ b/embedding/embedlite/embedprocess/EmbedLiteViewProcessParent.h
@@ -18,6 +18,7 @@ public:
     MOZ_IMPLICIT EmbedLiteViewProcessParent(const uint32_t &windowId,
                                             const uint32_t &id,
                                             const uint32_t &parentId,
+                                            const uintptr_t &parentBrowsingContext,
                                             const bool &isPrivateWindow,
                                             const bool &isDesktopMode);
     virtual ~EmbedLiteViewProcessParent() override;

--- a/embedding/embedlite/embedshared/EmbedLiteAppChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteAppChild.cpp
@@ -187,7 +187,7 @@ EmbedLiteAppChild::DeallocPEmbedLiteWindowChild(PEmbedLiteWindowChild* aActor)
   return true;
 }
 
-bool EmbedLiteAppChild::CreateWindow(const uint32_t& parentId, const uint32_t& chromeFlags, uint32_t* createdID, bool* cancel)
+bool EmbedLiteAppChild::CreateWindow(const uint32_t &parentId, const uint32_t &chromeFlags, uint32_t *createdID, bool *cancel)
 {
   return SendCreateWindow(parentId, chromeFlags, createdID, cancel);
 }

--- a/embedding/embedlite/embedshared/EmbedLiteAppChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteAppChild.cpp
@@ -187,9 +187,13 @@ EmbedLiteAppChild::DeallocPEmbedLiteWindowChild(PEmbedLiteWindowChild* aActor)
   return true;
 }
 
-bool EmbedLiteAppChild::CreateWindow(const uint32_t &parentId, const uint32_t &chromeFlags, uint32_t *createdID, bool *cancel)
+bool EmbedLiteAppChild::CreateWindow(const uint32_t &parentId,
+                                     const uintptr_t &parentBrowsingContext,
+                                     const uint32_t &chromeFlags,
+                                     uint32_t *createdID,
+                                     bool *cancel)
 {
-  return SendCreateWindow(parentId, chromeFlags, createdID, cancel);
+  return SendCreateWindow(parentId, parentBrowsingContext, chromeFlags, createdID, cancel);
 }
 
 EmbedLiteViewChildIface*

--- a/embedding/embedlite/embedshared/EmbedLiteAppChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteAppChild.h
@@ -32,7 +32,11 @@ public:
   EmbedLiteViewChildIface* GetViewByID(uint32_t aId) const override;
   EmbedLiteViewChildIface* GetViewByChromeParent(nsIWebBrowserChrome* aParent) const override;
   EmbedLiteWindowChild* GetWindowByID(uint32_t aWindowID);
-  bool CreateWindow(const uint32_t &parentId, const uint32_t &chromeFlags, uint32_t *createdID, bool *cancel) override;
+  bool CreateWindow(const uint32_t &parentId,
+                    const uintptr_t &parentBrowsingContext,
+                    const uint32_t &chromeFlags,
+                    uint32_t *createdID,
+                    bool *cancel) override;
   static EmbedLiteAppChild* GetInstance();
 
 protected:
@@ -44,6 +48,7 @@ protected:
   virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t &windowId,
                                                         const uint32_t &id,
                                                         const uint32_t &parentId,
+                                                        const uintptr_t &parentBrowsingContext,
                                                         const bool &isPrivateWindow,
                                                         const bool &isDesktopMode) = 0;
   virtual PEmbedLiteWindowChild* AllocPEmbedLiteWindowChild(const uint16_t &width, const uint16_t &height, const uint32_t &id, const uintptr_t &aListener) = 0;

--- a/embedding/embedlite/embedshared/EmbedLiteAppChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteAppChild.h
@@ -32,7 +32,7 @@ public:
   EmbedLiteViewChildIface* GetViewByID(uint32_t aId) const override;
   EmbedLiteViewChildIface* GetViewByChromeParent(nsIWebBrowserChrome* aParent) const override;
   EmbedLiteWindowChild* GetWindowByID(uint32_t aWindowID);
-  bool CreateWindow(const uint32_t& parentId, const uint32_t& chromeFlags, uint32_t* createdID, bool* cancel) override;
+  bool CreateWindow(const uint32_t &parentId, const uint32_t &chromeFlags, uint32_t *createdID, bool *cancel) override;
   static EmbedLiteAppChild* GetInstance();
 
 protected:
@@ -41,7 +41,11 @@ protected:
   // IPDL protocol impl
   virtual void ActorDestroy(ActorDestroyReason aWhy) override;
 
-  virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t&, const uint32_t&, const uint32_t& parentId, const bool& isPrivateWindow, const bool& isDesktopMode) = 0;
+  virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t &windowId,
+                                                        const uint32_t &id,
+                                                        const uint32_t &parentId,
+                                                        const bool &isPrivateWindow,
+                                                        const bool &isDesktopMode) = 0;
   virtual PEmbedLiteWindowChild* AllocPEmbedLiteWindowChild(const uint16_t &width, const uint16_t &height, const uint32_t &id, const uintptr_t &aListener) = 0;
 
 protected:

--- a/embedding/embedlite/embedshared/EmbedLiteAppChildIface.h
+++ b/embedding/embedlite/embedshared/EmbedLiteAppChildIface.h
@@ -12,8 +12,8 @@ class EmbedLiteAppChildIface
 {
 public:
   virtual EmbedLiteViewChildIface* GetViewByID(uint32_t aId) const = 0;
-  virtual EmbedLiteViewChildIface* GetViewByChromeParent(nsIWebBrowserChrome* aParent) const = 0;
-  virtual bool CreateWindow(const uint32_t& parentId, const uint32_t& chromeFlags, uint32_t* createdID, bool* cancel) = 0;
+  virtual EmbedLiteViewChildIface* GetViewByChromeParent(nsIWebBrowserChrome *aParent) const = 0;
+  virtual bool CreateWindow(const uint32_t &parentId, const uint32_t &chromeFlags, uint32_t *createdID, bool *cancel) = 0;
 };
 
 }}

--- a/embedding/embedlite/embedshared/EmbedLiteAppChildIface.h
+++ b/embedding/embedlite/embedshared/EmbedLiteAppChildIface.h
@@ -13,7 +13,11 @@ class EmbedLiteAppChildIface
 public:
   virtual EmbedLiteViewChildIface* GetViewByID(uint32_t aId) const = 0;
   virtual EmbedLiteViewChildIface* GetViewByChromeParent(nsIWebBrowserChrome *aParent) const = 0;
-  virtual bool CreateWindow(const uint32_t &parentId, const uint32_t &chromeFlags, uint32_t *createdID, bool *cancel) = 0;
+  virtual bool CreateWindow(const uint32_t &parentId,
+                            const uintptr_t &parentBrowsingContext,
+                            const uint32_t &chromeFlags,
+                            uint32_t *createdID,
+                            bool *cancel) = 0;
 };
 
 }}

--- a/embedding/embedlite/embedshared/EmbedLiteAppParent.h
+++ b/embedding/embedlite/embedshared/EmbedLiteAppParent.h
@@ -32,6 +32,7 @@ protected:
   virtual PEmbedLiteViewParent* AllocPEmbedLiteViewParent(const uint32_t &windowId,
                                                           const uint32_t &id,
                                                           const uint32_t &parentId,
+                                                          const uintptr_t &parentBrowsingContext,
                                                           const bool &isPrivateWindow,
                                                           const bool &isDesktopMode)  = 0;
   virtual bool DeallocPEmbedLiteViewParent(PEmbedLiteViewParent*)  = 0;
@@ -44,6 +45,7 @@ protected:
   virtual mozilla::ipc::IPCResult RecvObserve(const nsCString &topic,
                                               const nsString &data)  = 0;
   virtual mozilla::ipc::IPCResult RecvCreateWindow(const uint32_t &parentId,
+                                                   const uintptr_t &parentBrowsingContext,
                                                    const uint32_t &chromeFlags,
                                                    uint32_t *createdID,
                                                    bool *cancel)  = 0;

--- a/embedding/embedlite/embedshared/EmbedLiteAppParent.h
+++ b/embedding/embedlite/embedshared/EmbedLiteAppParent.h
@@ -29,7 +29,11 @@ protected:
 
   // IPDL implementation
   virtual void ActorDestroy(ActorDestroyReason aWhy)  = 0;
-  virtual PEmbedLiteViewParent* AllocPEmbedLiteViewParent(const uint32_t&, const uint32_t&, const uint32_t&, const bool&, const bool &)  = 0;
+  virtual PEmbedLiteViewParent* AllocPEmbedLiteViewParent(const uint32_t &windowId,
+                                                          const uint32_t &id,
+                                                          const uint32_t &parentId,
+                                                          const bool &isPrivateWindow,
+                                                          const bool &isDesktopMode)  = 0;
   virtual bool DeallocPEmbedLiteViewParent(PEmbedLiteViewParent*)  = 0;
   virtual PEmbedLiteWindowParent* AllocPEmbedLiteWindowParent(const uint16_t &width, const uint16_t &height, const uint32_t &id, const uintptr_t &aListener)  = 0;
   virtual bool DeallocPEmbedLiteWindowParent(PEmbedLiteWindowParent*)  = 0;

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -103,6 +103,7 @@ static void ReadAZPCPrefs()
 EmbedLiteViewChild::EmbedLiteViewChild(const uint32_t &aWindowId,
                                        const uint32_t &aId,
                                        const uint32_t &aParentId,
+                                       mozilla::dom::BrowsingContext *parentBrowsingContext,
                                        const bool &isPrivateWindow,
                                        const bool &isDesktopMode)
   : mId(aId)
@@ -131,11 +132,12 @@ EmbedLiteViewChild::EmbedLiteViewChild(const uint32_t &aWindowId,
   mWindow = EmbedLiteAppChild::GetInstance()->GetWindowByID(aWindowId);
   MOZ_ASSERT(mWindow != nullptr);
 
-  MessageLoop::current()->PostTask(NewRunnableMethod<const uint32_t, const bool, const bool>
+  MessageLoop::current()->PostTask(NewRunnableMethod<const uint32_t, mozilla::dom::BrowsingContext*, const bool, const bool>
                                    ("mozilla::embedlite::EmbedLiteViewChild::InitGeckoWindow",
                                     this,
                                     &EmbedLiteViewChild::InitGeckoWindow,
                                     aParentId,
+                                    parentBrowsingContext,
                                     isPrivateWindow,
                                     isDesktopMode));
 }
@@ -205,7 +207,10 @@ mozilla::ipc::IPCResult EmbedLiteViewChild::RecvDestroy()
 }
 
 void
-EmbedLiteViewChild::InitGeckoWindow(const uint32_t parentId, const bool isPrivateWindow, const bool isDesktopMode)
+EmbedLiteViewChild::InitGeckoWindow(const uint32_t parentId,
+                                    mozilla::dom::BrowsingContext *parentBrowsingContext,
+                                    const bool isPrivateWindow,
+                                    const bool isDesktopMode)
 {
   if (!mWindow) {
     LOGT("Init called for already destroyed object");
@@ -217,7 +222,8 @@ EmbedLiteViewChild::InitGeckoWindow(const uint32_t parentId, const bool isPrivat
     return;
   }
 
-  LOGT("parentID: %u", parentId);
+  LOGT("parentID: %u thread id: %ld", parentId, syscall(SYS_gettid));
+
 
   mWidget = new EmbedLitePuppetWidget(this);
   LOGT("puppet widget: %p", GetPuppetWidget());
@@ -244,23 +250,8 @@ EmbedLiteViewChild::InitGeckoWindow(const uint32_t parentId, const bool isPrivat
   mHelper = new BrowserChildHelper(this, mId);
   mChrome->SetBrowserChildHelper(mHelper.get());
 
-  // Dig out parent browsing context. If this is created with window.open(), we need
-  // to pass parent context as an argument for browsing context of this view.
-  // That's for making sure window.opener is set properly and window.close() can be
-  // called by the JS.
-  EmbedLiteViewChild *parentView = nullptr;
-  if (parentId > 0) {
-    EmbedLiteViewChildIface *childIface = EmbedLiteAppChild::GetInstance()->GetViewByID(parentId);
-    if (childIface) {
-      parentView = static_cast<EmbedLiteViewChild*>(childIface);
-    }
-  }
-
-  BrowsingContext *parentBrowsingContext = nullptr;
-  if (parentId > 0 && parentView) {
-    parentBrowsingContext = parentView->GetBrowsingContext();
-  }
-
+  // If this is created with window.open() or otherwise via WindowCreator
+  // we'll receive parent BrowsingContext as an argument.
   // Create a BrowsingContext for our windowless browser.
   RefPtr<BrowsingContext> browsingContext = BrowsingContext::CreateDetached(nullptr, parentBrowsingContext, EmptyString(), BrowsingContext::Type::Content);
   browsingContext->SetUsePrivateBrowsing(isPrivateWindow); // Needs to be called before attaching
@@ -273,6 +264,10 @@ EmbedLiteViewChild::InitGeckoWindow(const uint32_t parentId, const bool isPrivat
   if (canonicalBrowsingContext) {
     secureBrowserUI = canonicalBrowsingContext->GetSecureBrowserUI();
     Unused << secureBrowserUI;
+  }
+
+  if (browsingContext) {
+      LOGT("Created browsing context id: %" PRId64 " opener id: %" PRId64 "", browsingContext->Id(), browsingContext->GetOpenerId());
   }
 
   // nsWebBrowser::Create creates nsDocShell, calls InitWindow for nsIBaseWindow,
@@ -747,12 +742,6 @@ bool EmbedLiteViewChild::SetDesktopModeInternal(const bool aDesktopMode) {
     return true;
   }
   return false;
-}
-
-mozilla::dom::BrowsingContext *EmbedLiteViewChild::GetBrowsingContext() const
-{
-  nsCOMPtr<nsIDocShell> docShell = do_GetInterface(mWebNavigation);
-  return docShell->GetBrowsingContext();
 }
 
 mozilla::ipc::IPCResult EmbedLiteViewChild::RecvSetThrottlePainting(const bool &aThrottle)

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -100,9 +100,11 @@ static void ReadAZPCPrefs()
   Preferences::AddBoolVarCache(&sAllowKeyWordURL, "keyword.enabled", sAllowKeyWordURL);
 }
 
-EmbedLiteViewChild::EmbedLiteViewChild(const uint32_t& aWindowId, const uint32_t& aId,
-                                       const uint32_t& aParentId, const bool& isPrivateWindow,
-                                       const bool& isDesktopMode)
+EmbedLiteViewChild::EmbedLiteViewChild(const uint32_t &aWindowId,
+                                       const uint32_t &aId,
+                                       const uint32_t &aParentId,
+                                       const bool &isPrivateWindow,
+                                       const bool &isDesktopMode)
   : mId(aId)
   , mOuterId(0)
   , mWindow(nullptr)

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.h
@@ -23,6 +23,9 @@
 class nsWebBrowser;
 
 namespace mozilla {
+namespace dom {
+class BrowsingContext;
+}
 
 namespace layers {
 struct FrameMetrics;
@@ -47,6 +50,7 @@ public:
   EmbedLiteViewChild(const uint32_t &windowId,
                      const uint32_t &id,
                      const uint32_t &parentId,
+                     mozilla::dom::BrowsingContext *parentBrowsingContext,
                      const bool &isPrivateWindow,
                      const bool &isDesktopMode);
 
@@ -225,13 +229,14 @@ private:
   friend class EmbedLiteAppChild;
   friend class PEmbedLiteViewChild;
 
-  void InitGeckoWindow(const uint32_t parentId, const bool isPrivateWindow, const bool isDesktopMode);
+  void InitGeckoWindow(const uint32_t parentId,
+                       mozilla::dom::BrowsingContext *parentBrowsingContext,
+                       const bool isPrivateWindow,
+                       const bool isDesktopMode);
   void InitEvent(WidgetGUIEvent& event, nsIntPoint* aPoint = nullptr);
   nsresult DispatchKeyPressEvent(nsIWidget *widget, const EventMessage &message, const int &domKeyCode, const int &gmodifiers, const int &charCode);
   void SetDesktopMode(const bool aDesktopMode);
   bool SetDesktopModeInternal(const bool aDesktopMode);
-
-  mozilla::dom::BrowsingContext *GetBrowsingContext() const;
 
   const uint32_t mId;
   uint64_t mOuterId;

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.h
@@ -44,9 +44,11 @@ class EmbedLiteViewChild : public PEmbedLiteViewChild,
   typedef mozilla::layers::APZEventState APZEventState;
 
 public:
-  EmbedLiteViewChild(const uint32_t& windowId, const uint32_t& id,
-                     const uint32_t& parentId, const bool& isPrivateWindow,
-                     const bool& isDesktopMode);
+  EmbedLiteViewChild(const uint32_t &windowId,
+                     const uint32_t &id,
+                     const uint32_t &parentId,
+                     const bool &isPrivateWindow,
+                     const bool &isDesktopMode);
 
   NS_DECL_NSIEMBEDBROWSERCHROMELISTENER
   NS_IMETHOD QueryInterface(REFNSIID aIID, void** aInstancePtr) override;

--- a/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
@@ -24,7 +24,11 @@ using namespace mozilla::widget;
 namespace mozilla {
 namespace embedlite {
 
-EmbedLiteViewParent::EmbedLiteViewParent(const uint32_t& windowId, const uint32_t& id, const uint32_t& parentId, const bool& isPrivateWindow, const bool &isDesktopMode)
+EmbedLiteViewParent::EmbedLiteViewParent(const uint32_t &windowId,
+                                         const uint32_t &id,
+                                         const uint32_t &parentId,
+                                         const bool &isPrivateWindow,
+                                         const bool &isDesktopMode)
   : mWindowId(windowId)
   , mId(id)
   , mViewAPIDestroyed(false)

--- a/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
@@ -27,6 +27,7 @@ namespace embedlite {
 EmbedLiteViewParent::EmbedLiteViewParent(const uint32_t &windowId,
                                          const uint32_t &id,
                                          const uint32_t &parentId,
+                                         const uintptr_t &parentBrowsingContext,
                                          const bool &isPrivateWindow,
                                          const bool &isDesktopMode)
   : mWindowId(windowId)
@@ -51,6 +52,9 @@ EmbedLiteViewParent::EmbedLiteViewParent(const uint32_t &windowId,
   }
 
   mWindow.AddObserver(this);
+
+  // This could be turned into MaybeDiscardedBrowsingContext
+  Unused << parentBrowsingContext;
 }
 
 NS_IMETHODIMP EmbedLiteViewParent::QueryInterface(REFNSIID aIID, void** aInstancePtr)

--- a/embedding/embedlite/embedshared/EmbedLiteViewParent.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewParent.h
@@ -29,7 +29,11 @@ class EmbedLiteViewParent : public PEmbedLiteViewParent,
 {
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(EmbedLiteViewParent)
 public:
-  EmbedLiteViewParent(const uint32_t& windowId, const uint32_t& id, const uint32_t& parentId, const bool& isPrivateWindow, const bool& isDesktopMode);
+  EmbedLiteViewParent(const uint32_t &windowId,
+                      const uint32_t &id,
+                      const uint32_t &parentId,
+                      const bool &isPrivateWindow,
+                      const bool &isDesktopMode);
 
   NS_DECL_EMBEDLITEVIEWIFACE
   NS_IMETHOD QueryInterface(REFNSIID aIID, void** aInstancePtr) override;

--- a/embedding/embedlite/embedshared/EmbedLiteViewParent.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewParent.h
@@ -32,6 +32,7 @@ public:
   EmbedLiteViewParent(const uint32_t &windowId,
                       const uint32_t &id,
                       const uint32_t &parentId,
+                      const uintptr_t &parentBrowsingContext,
                       const bool &isPrivateWindow,
                       const bool &isDesktopMode);
 

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadChild.cpp
@@ -7,6 +7,7 @@
 #include "EmbedLiteAppThreadChild.h"
 #include "EmbedLiteViewThreadChild.h"
 #include "EmbedLiteWindowThreadChild.h"
+#include "mozilla/dom/BrowsingContext.h"
 #include "mozilla/layers/PCompositorBridgeChild.h"
 
 namespace mozilla {
@@ -37,11 +38,20 @@ PEmbedLiteViewChild*
 EmbedLiteAppThreadChild::AllocPEmbedLiteViewChild(const uint32_t &windowId,
                                                   const uint32_t &id,
                                                   const uint32_t &parentId,
+                                                  const uintptr_t &parentBrowsingContext,
                                                   const bool &isPrivateWindow,
                                                   const bool &isDesktopMode)
 {
   LOGT("id:%u, parentId:%u", id, parentId);
-  EmbedLiteViewThreadChild* view = new EmbedLiteViewThreadChild(windowId, id, parentId, isPrivateWindow, isDesktopMode);
+
+  mozilla::dom::BrowsingContext *parentBrowsingContextPtr = nullptr;
+  if (parentBrowsingContext) {
+    parentBrowsingContextPtr = reinterpret_cast<mozilla::dom::BrowsingContext*>(parentBrowsingContext);
+  }
+
+  EmbedLiteViewThreadChild* view = new EmbedLiteViewThreadChild(windowId, id, parentId,
+                                                                parentBrowsingContextPtr,
+                                                                isPrivateWindow, isDesktopMode);
   mWeakViewMap[id] = view;
   view->AddRef();
   return view;

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadChild.cpp
@@ -34,8 +34,11 @@ EmbedLiteAppThreadChild::~EmbedLiteAppThreadChild()
 }
 
 PEmbedLiteViewChild*
-EmbedLiteAppThreadChild::AllocPEmbedLiteViewChild(const uint32_t& windowId, const uint32_t& id, const uint32_t& parentId, const bool& isPrivateWindow,
-                                                  const bool& isDesktopMode)
+EmbedLiteAppThreadChild::AllocPEmbedLiteViewChild(const uint32_t &windowId,
+                                                  const uint32_t &id,
+                                                  const uint32_t &parentId,
+                                                  const bool &isPrivateWindow,
+                                                  const bool &isDesktopMode)
 {
   LOGT("id:%u, parentId:%u", id, parentId);
   EmbedLiteViewThreadChild* view = new EmbedLiteViewThreadChild(windowId, id, parentId, isPrivateWindow, isDesktopMode);

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadChild.h
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadChild.h
@@ -20,7 +20,10 @@ public:
 protected:
   virtual ~EmbedLiteAppThreadChild();
 
-  virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t&, const uint32_t&, const uint32_t& parentId, const bool& isPrivateWindow,
+  virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t &windowId,
+                                                        const uint32_t &id,
+                                                        const uint32_t &parentId,
+                                                        const bool &isPrivateWindow,
                                                         const bool &isDesktopMode) override;
   virtual PEmbedLiteWindowChild* AllocPEmbedLiteWindowChild(const uint16_t &width, const uint16_t &height, const uint32_t &id, const uintptr_t &aListener) override;
   virtual mozilla::layers::PCompositorBridgeChild* AllocPCompositorBridgeChild(Transport* aTransport, ProcessId aOtherProcess);

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadChild.h
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadChild.h
@@ -23,6 +23,7 @@ protected:
   virtual PEmbedLiteViewChild* AllocPEmbedLiteViewChild(const uint32_t &windowId,
                                                         const uint32_t &id,
                                                         const uint32_t &parentId,
+                                                        const uintptr_t &parentBrowsingContext,
                                                         const bool &isPrivateWindow,
                                                         const bool &isDesktopMode) override;
   virtual PEmbedLiteWindowChild* AllocPEmbedLiteWindowChild(const uint16_t &width, const uint16_t &height, const uint32_t &id, const uintptr_t &aListener) override;

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.cpp
@@ -60,10 +60,10 @@ mozilla::ipc::IPCResult EmbedLiteAppThreadParent::RecvReadyToShutdown()
   return IPC_OK();
 }
 
-mozilla::ipc::IPCResult EmbedLiteAppThreadParent::RecvCreateWindow(const uint32_t& parentId,
-                                           const uint32_t& chromeFlags,
-                                           uint32_t* createdID,
-                                           bool* cancel)
+mozilla::ipc::IPCResult EmbedLiteAppThreadParent::RecvCreateWindow(const uint32_t &parentId,
+                                                                   const uint32_t &chromeFlags,
+                                                                   uint32_t *createdID,
+                                                                   bool *cancel)
 {
   *createdID = mApp->CreateWindowRequested(chromeFlags, parentId);
   *cancel = !*createdID;
@@ -77,8 +77,11 @@ EmbedLiteAppThreadParent::ActorDestroy(ActorDestroyReason aWhy)
 }
 
 PEmbedLiteViewParent*
-EmbedLiteAppThreadParent::AllocPEmbedLiteViewParent(const uint32_t& windowId, const uint32_t& id, const uint32_t& parentId, const bool& isPrivateWindow,
-                                                    const bool& isDesktopMode)
+EmbedLiteAppThreadParent::AllocPEmbedLiteViewParent(const uint32_t &windowId,
+                                                    const uint32_t &id,
+                                                    const uint32_t &parentId,
+                                                    const bool &isPrivateWindow,
+                                                    const bool &isDesktopMode)
 {
   LOGT("id:%u, parent:%u", id, parentId);
   EmbedLiteViewThreadParent* p = new EmbedLiteViewThreadParent(windowId, id, parentId, isPrivateWindow, isDesktopMode);

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.cpp
@@ -61,11 +61,12 @@ mozilla::ipc::IPCResult EmbedLiteAppThreadParent::RecvReadyToShutdown()
 }
 
 mozilla::ipc::IPCResult EmbedLiteAppThreadParent::RecvCreateWindow(const uint32_t &parentId,
+                                                                   const uintptr_t &parentBrowsingContext,
                                                                    const uint32_t &chromeFlags,
                                                                    uint32_t *createdID,
                                                                    bool *cancel)
 {
-  *createdID = mApp->CreateWindowRequested(chromeFlags, parentId);
+  *createdID = mApp->CreateWindowRequested(chromeFlags, parentId, parentBrowsingContext);
   *cancel = !*createdID;
   return IPC_OK();
 }
@@ -80,11 +81,14 @@ PEmbedLiteViewParent*
 EmbedLiteAppThreadParent::AllocPEmbedLiteViewParent(const uint32_t &windowId,
                                                     const uint32_t &id,
                                                     const uint32_t &parentId,
+                                                    const uintptr_t &parentBrowsingContext,
                                                     const bool &isPrivateWindow,
                                                     const bool &isDesktopMode)
 {
   LOGT("id:%u, parent:%u", id, parentId);
-  EmbedLiteViewThreadParent* p = new EmbedLiteViewThreadParent(windowId, id, parentId, isPrivateWindow, isDesktopMode);
+  EmbedLiteViewThreadParent* p = new EmbedLiteViewThreadParent(windowId, id, parentId,
+                                                               parentBrowsingContext,
+                                                               isPrivateWindow, isDesktopMode);
   p->AddRef();
   return p;
 }

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.h
@@ -24,7 +24,11 @@ class EmbedLiteAppThreadParent : public EmbedLiteAppParent
 protected:
   // IPDL implementation
   virtual void ActorDestroy(ActorDestroyReason aWhy) override;
-  virtual PEmbedLiteViewParent* AllocPEmbedLiteViewParent(const uint32_t&, const uint32_t&, const uint32_t&, const bool&, const bool&) override;
+  virtual PEmbedLiteViewParent* AllocPEmbedLiteViewParent(const uint32_t &windowId,
+                                                          const uint32_t &id,
+                                                          const uint32_t &parentId,
+                                                          const bool &isPrivateWindow,
+                                                          const bool &isDesktopMode) override;
   virtual bool DeallocPEmbedLiteViewParent(PEmbedLiteViewParent*) override;
   virtual PEmbedLiteWindowParent* AllocPEmbedLiteWindowParent(const uint16_t &width, const uint16_t &height, const uint32_t &id, const uintptr_t &aListener) override;
   virtual bool DeallocPEmbedLiteWindowParent(PEmbedLiteWindowParent*) override;

--- a/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteAppThreadParent.h
@@ -27,6 +27,7 @@ protected:
   virtual PEmbedLiteViewParent* AllocPEmbedLiteViewParent(const uint32_t &windowId,
                                                           const uint32_t &id,
                                                           const uint32_t &parentId,
+                                                          const uintptr_t &parentBrowsingContext,
                                                           const bool &isPrivateWindow,
                                                           const bool &isDesktopMode) override;
   virtual bool DeallocPEmbedLiteViewParent(PEmbedLiteViewParent*) override;
@@ -39,6 +40,7 @@ protected:
   virtual mozilla::ipc::IPCResult RecvObserve(const nsCString &topic,
                                               const nsString &data) override;
   virtual mozilla::ipc::IPCResult RecvCreateWindow(const uint32_t &parentId,
+                                                   const uintptr_t &parentBrowsingContext,
                                                    const uint32_t &chromeFlags,
                                                    uint32_t *createdID,
                                                    bool *cancel) override;

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -10,11 +10,11 @@
 namespace mozilla {
 namespace embedlite {
 
-EmbedLiteViewThreadChild::EmbedLiteViewThreadChild(const uint32_t& windowId,
-                                                   const uint32_t& id,
-                                                   const uint32_t& parentId,
-                                                   const bool& isPrivateWindow,
-                                                   const bool& isDesktopMode)
+EmbedLiteViewThreadChild::EmbedLiteViewThreadChild(const uint32_t &windowId,
+                                                   const uint32_t &id,
+                                                   const uint32_t &parentId,
+                                                   const bool &isPrivateWindow,
+                                                   const bool &isDesktopMode)
   : EmbedLiteViewChild(windowId, id, parentId, isPrivateWindow, isDesktopMode)
 {
   LOGT();

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -7,15 +7,18 @@
 
 #include "EmbedLiteViewThreadChild.h"
 
+#include "mozilla/dom/BrowsingContext.h"
+
 namespace mozilla {
 namespace embedlite {
 
 EmbedLiteViewThreadChild::EmbedLiteViewThreadChild(const uint32_t &windowId,
                                                    const uint32_t &id,
                                                    const uint32_t &parentId,
+                                                   mozilla::dom::BrowsingContext *parentBrowsingContext,
                                                    const bool &isPrivateWindow,
                                                    const bool &isDesktopMode)
-  : EmbedLiteViewChild(windowId, id, parentId, isPrivateWindow, isDesktopMode)
+  : EmbedLiteViewChild(windowId, id, parentId, parentBrowsingContext, isPrivateWindow, isDesktopMode)
 {
   LOGT();
 }

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
@@ -9,6 +9,10 @@
 #include "EmbedLiteViewChild.h"
 
 namespace mozilla {
+namespace dom {
+class BrowsingContext;
+}
+
 namespace embedlite {
 
 class EmbedLiteViewThreadChild : public EmbedLiteViewChild
@@ -17,6 +21,7 @@ public:
   EmbedLiteViewThreadChild(const uint32_t &windowId,
                            const uint32_t &id,
                            const uint32_t &parentId,
+                           mozilla::dom::BrowsingContext *parentBrowsingContext,
                            const bool &isPrivateWindow,
                            const bool &isDesktopMode);
 protected:

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
@@ -14,9 +14,11 @@ namespace embedlite {
 class EmbedLiteViewThreadChild : public EmbedLiteViewChild
 {
 public:
-  EmbedLiteViewThreadChild(const uint32_t& windowId, const uint32_t& id,
-                           const uint32_t& parentId, const bool& isPrivateWindow,
-                           const bool& isDesktopMode);
+  EmbedLiteViewThreadChild(const uint32_t &windowId,
+                           const uint32_t &id,
+                           const uint32_t &parentId,
+                           const bool &isPrivateWindow,
+                           const bool &isDesktopMode);
 protected:
   virtual ~EmbedLiteViewThreadChild() override;
 

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -10,7 +10,10 @@
 namespace mozilla {
 namespace embedlite {
 
-EmbedLiteViewThreadParent::EmbedLiteViewThreadParent(const uint32_t& windowId, const uint32_t& id, const uint32_t& parentId, const bool& isPrivateWindow,
+EmbedLiteViewThreadParent::EmbedLiteViewThreadParent(const uint32_t &windowId,
+                                                     const uint32_t &id,
+                                                     const uint32_t &parentId,
+                                                     const bool &isPrivateWindow,
                                                      const bool &isDesktopMode)
   : EmbedLiteViewParent(windowId, id, parentId, isPrivateWindow, isDesktopMode)
 {

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -13,9 +13,10 @@ namespace embedlite {
 EmbedLiteViewThreadParent::EmbedLiteViewThreadParent(const uint32_t &windowId,
                                                      const uint32_t &id,
                                                      const uint32_t &parentId,
+                                                     const uintptr_t &parentBrowsingContext,
                                                      const bool &isPrivateWindow,
                                                      const bool &isDesktopMode)
-  : EmbedLiteViewParent(windowId, id, parentId, isPrivateWindow, isDesktopMode)
+  : EmbedLiteViewParent(windowId, id, parentId, parentBrowsingContext, isPrivateWindow, isDesktopMode)
 {
 }
 

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
@@ -17,6 +17,7 @@ public:
   EmbedLiteViewThreadParent(const uint32_t &windowId,
                             const uint32_t &id,
                             const uint32_t &parentId,
+                            const uintptr_t &parentBrowsingContext,
                             const bool &isPrivateWindow,
                             const bool &isDesktopMode);
 

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
@@ -14,7 +14,11 @@ namespace embedlite {
 class EmbedLiteViewThreadParent : public EmbedLiteViewParent
 {
 public:
-  EmbedLiteViewThreadParent(const uint32_t& windowId, const uint32_t& id, const uint32_t& parentId, const bool& isPrivateWindow, const bool& isDesktopMode);
+  EmbedLiteViewThreadParent(const uint32_t &windowId,
+                            const uint32_t &id,
+                            const uint32_t &parentId,
+                            const bool &isPrivateWindow,
+                            const bool &isDesktopMode);
 
 protected:
   virtual ~EmbedLiteViewThreadParent();


### PR DESCRIPTION
This commit makes it possible to pass back parent browsing context when
new view is created.

See also:
https://github.com/sailfishos/sailfish-browser/pull/961
https://github.com/sailfishos/qtmozembed/pull/30