### PR TITLE
Ensure clipboard service can be accessed. Fixes JB#56647 OMP#JOLLA-578

### DIFF
--- a/embedding/embedlite/components/nsClipboard.h
+++ b/embedding/embedlite/components/nsClipboard.h
@@ -13,6 +13,7 @@
 #include "nsIObserverService.h"
 #include "nsIObserver.h"
 #include "nsString.h"
+#include "nsWidgetsCID.h"
 
 /* Native Qt Clipboard wrapper */
 class nsEmbedClipboard : public nsIClipboard, public nsIObserver
@@ -36,11 +37,7 @@ private:
     bool mActive;
 };
 
-// b27ca13c-b6d5-11e2-b8c8-1b7d85770900
-#define NS_EMBED_CLIPBOARD_SERVICE_CID \
-{ 0xb27ca13c, \
-  0xb6d5, \
-  0x11e2, \
-  { 0xb8, 0xc8, 0x1b, 0x7d, 0x85, 0x77, 0x09, 0x00 }}
+// {8B5314BA-DB01-11d2-96CE-0060B0FB9956}
+#define NS_EMBED_CLIPBOARD_SERVICE_CID NS_CLIPBOARD_CID
 
 #endif // nsEmbedClipboard_h__


### PR DESCRIPTION
The CID used to access the clipboard service in nsCopySupport fails (it doesn't match the CID of nsIClipboard). This prevents the embedlite nsIClipboard service from being accessed.

Using the contract ID instead of the CID allows it to be accessed correctly.