### PR TITLE
Ensure zooming is always allowed if desktop mode is active. Fixes JB#56767 OMP#JOLLA-609

### DIFF
--- a/rpm/0083-sailfishos-gecko-dev-Disallow-page-zooming-if-the-me.patch
+++ b/rpm/0083-sailfishos-gecko-dev-Disallow-page-zooming-if-the-me.patch
@@ -4,19 +4,20 @@ Date: Thu, 11 Nov 2021 06:51:59 +0000
 Subject: [PATCH] [sailfishos][gecko-dev] Disallow page zooming if the meta
  viewport scale is fixed. JB#56149 OMP#JOLLA-49
 
+Zooming is always allowed if desktop mode is active. JB#56767
+OMP#JOLLA-609
 ---
- layout/base/nsLayoutUtils.cpp | 16 +++++++++++++++-
- 1 file changed, 15 insertions(+), 1 deletion(-)
+ layout/base/nsLayoutUtils.cpp | 25 ++++++++++++++++++++++---
+ 1 file changed, 22 insertions(+), 3 deletions(-)
 
 diff --git a/layout/base/nsLayoutUtils.cpp b/layout/base/nsLayoutUtils.cpp
-index 2cd2903a8fc8..85e290c0d90f 100644
+index 2cd2903a8fc8..5c06c5532fa7 100644
 --- a/layout/base/nsLayoutUtils.cpp
 +++ b/layout/base/nsLayoutUtils.cpp
-@@ -694,13 +694,27 @@ bool nsLayoutUtils::AsyncPanZoomEnabled(nsIFrame* aFrame) {
+@@ -694,15 +694,34 @@ bool nsLayoutUtils::AsyncPanZoomEnabled(nsIFrame* aFrame) {
    return widget->AsyncPanZoomEnabled();
  }
  
-+
 +static bool DocumentHasFixedUnityZoom(const mozilla::dom::Document* aDocument)
 +{
 +  if (!aDocument) {
@@ -30,17 +31,24 @@ index 2cd2903a8fc8..85e290c0d90f 100644
 +          metaData.mUserScalable.EqualsLiteral("false");
 +}
 +
++static bool IsDesktopView(const mozilla::dom::Document* aDocument) {
++  nsCOMPtr<nsPIDOMWindowOuter> window = aDocument ? aDocument->GetWindow() : nullptr;
++  return window ? window->IsDesktopModeViewport() : false;
++}
++
  bool nsLayoutUtils::AllowZoomingForDocument(
      const mozilla::dom::Document* aDocument) {
    // True if we allow zooming for all documents on this platform, or if we are
    // in RDM and handling meta viewports, which force zoom under some
    // circumstances.
++
    BrowsingContext* bc = aDocument ? aDocument->GetBrowsingContext() : nullptr;
 -  return StaticPrefs::apz_allow_zooming() ||
+-         (bc && bc->InRDMPane() &&
+-          nsLayoutUtils::ShouldHandleMetaViewport(aDocument));
 +  return (StaticPrefs::apz_allow_zooming() && !DocumentHasFixedUnityZoom(aDocument)) ||
-          (bc && bc->InRDMPane() &&
-           nsLayoutUtils::ShouldHandleMetaViewport(aDocument));
++         (bc && bc->InRDMPane() && nsLayoutUtils::ShouldHandleMetaViewport(aDocument)) ||
++         IsDesktopView(aDocument);
  }
--- 
-2.26.2
-
+ 
+ float nsLayoutUtils::GetCurrentAPZResolutionScale(PresShell* aPresShell) {


### PR DESCRIPTION
If desktop mode is active then we should allow page zoomingi by the user (pinch-to-zoom), even if the metadata for the page has "user-scalable=no" set.