### PR TITLE
Pass double taps to embedhelper.js. JB#56765 OMP#JOLLA-607

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -111,7 +111,6 @@ pref("gfx.xrender.enabled", false);
 // AZPC overrides, see EmbedLiteViewChild.cpp
 pref("embedlite.azpc.handle.viewport", true);
 pref("embedlite.azpc.handle.singletap", false);
-pref("embedlite.azpc.handle.doubletap", true);
 pref("embedlite.azpc.handle.longtap", false);
 pref("embedlite.azpc.handle.scroll", true);
 pref("embedlite.azpc.json.viewport", true);

--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -107,15 +107,19 @@ pref("media.prefer-gstreamer", true);
 pref("media.gstreamer.enable-blacklist", false);
 // Disable X backend on GTK
 pref("gfx.xrender.enabled", false);
+
+// AZPC overrides, see EmbedLiteViewChild.cpp
 pref("embedlite.azpc.handle.viewport", true);
-pref("embedlite.azpc.handle.singletap", true);
-pref("embedlite.azpc.handle.longtap", true);
+pref("embedlite.azpc.handle.singletap", false);
+pref("embedlite.azpc.handle.doubletap", true);
+pref("embedlite.azpc.handle.longtap", false);
 pref("embedlite.azpc.handle.scroll", true);
-pref("embedlite.azpc.json.viewport", false);
-pref("embedlite.azpc.json.singletap", false);
-pref("embedlite.azpc.json.doubletap", false);
-pref("embedlite.azpc.json.longtap", false);
+pref("embedlite.azpc.json.viewport", true);
+pref("embedlite.azpc.json.singletap", true);
+pref("embedlite.azpc.json.doubletap", true);
+pref("embedlite.azpc.json.longtap", true);
 pref("embedlite.azpc.json.scroll", false);
+
 // Make gecko compositor use GL context/surface provided by the application.
 pref("embedlite.compositor.external_gl_context", false);
 // Request the application to create GLContext for the compositor as

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -70,7 +70,6 @@ static struct {
     bool viewport;
     bool scroll;
     bool singleTap;
-    bool doubleTap;
     bool longTap;
 } sHandleDefaultAZPC;
 static struct {
@@ -88,7 +87,6 @@ static void ReadAZPCPrefs()
   // Init default azpc notifications behavior
   Preferences::AddBoolVarCache(&sHandleDefaultAZPC.viewport, "embedlite.azpc.handle.viewport", true);
   Preferences::AddBoolVarCache(&sHandleDefaultAZPC.singleTap, "embedlite.azpc.handle.singletap", false);
-  Preferences::AddBoolVarCache(&sHandleDefaultAZPC.doubleTap, "embedlite.azpc.handle.doubletap", true);
   Preferences::AddBoolVarCache(&sHandleDefaultAZPC.longTap, "embedlite.azpc.handle.longtap", false);
   Preferences::AddBoolVarCache(&sHandleDefaultAZPC.scroll, "embedlite.azpc.handle.scroll", true);
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChild.cpp
@@ -47,6 +47,7 @@
 #include "mozilla/layers/InputAPZContext.h" // for InputAPZContext
 #include "nsIFrame.h"                       // for nsIFrame
 #include "FrameLayerBuilder.h"              // for FrameLayerbuilder
+#include "nsReadableUtils.h"
 
 #include <sys/syscall.h>
 
@@ -86,15 +87,15 @@ static void ReadAZPCPrefs()
 {
   // Init default azpc notifications behavior
   Preferences::AddBoolVarCache(&sHandleDefaultAZPC.viewport, "embedlite.azpc.handle.viewport", true);
-  Preferences::AddBoolVarCache(&sHandleDefaultAZPC.singleTap, "embedlite.azpc.handle.singletap", true);
+  Preferences::AddBoolVarCache(&sHandleDefaultAZPC.singleTap, "embedlite.azpc.handle.singletap", false);
   Preferences::AddBoolVarCache(&sHandleDefaultAZPC.doubleTap, "embedlite.azpc.handle.doubletap", true);
-  Preferences::AddBoolVarCache(&sHandleDefaultAZPC.longTap, "embedlite.azpc.handle.longtap", true);
+  Preferences::AddBoolVarCache(&sHandleDefaultAZPC.longTap, "embedlite.azpc.handle.longtap", false);
   Preferences::AddBoolVarCache(&sHandleDefaultAZPC.scroll, "embedlite.azpc.handle.scroll", true);
 
-  Preferences::AddBoolVarCache(&sPostAZPCAsJson.viewport, "embedlite.azpc.json.viewport", false);
-  Preferences::AddBoolVarCache(&sPostAZPCAsJson.singleTap, "embedlite.azpc.json.singletap", false);
+  Preferences::AddBoolVarCache(&sPostAZPCAsJson.viewport, "embedlite.azpc.json.viewport", true);
+  Preferences::AddBoolVarCache(&sPostAZPCAsJson.singleTap, "embedlite.azpc.json.singletap", true);
   Preferences::AddBoolVarCache(&sPostAZPCAsJson.doubleTap, "embedlite.azpc.json.doubletap", false);
-  Preferences::AddBoolVarCache(&sPostAZPCAsJson.longTap, "embedlite.azpc.json.longtap", false);
+  Preferences::AddBoolVarCache(&sPostAZPCAsJson.longTap, "embedlite.azpc.json.longtap", true);
   Preferences::AddBoolVarCache(&sPostAZPCAsJson.scroll, "embedlite.azpc.json.scroll", false);
 
   Preferences::AddBoolVarCache(&sAllowKeyWordURL, "keyword.enabled", sAllowKeyWordURL);
@@ -961,6 +962,31 @@ EmbedLiteViewChild::InitEvent(WidgetGUIEvent& event, nsIntPoint* aPoint)
   event.mTime = PR_Now() / 1000;
 }
 
+// Returns true if the element is interested in double click events
+static bool ElementSupportsDoubleClick(Element *element)
+{
+  nsAutoString attribute;
+  element->GetAttribute(NS_LITERAL_STRING("ondblclick"), attribute);
+  if (!attribute.IsEmpty()) {
+    // Element has a dblclick attribute
+    return true;
+  }
+
+  element->GetAttribute(NS_LITERAL_STRING("jsaction"), attribute);
+  if (!attribute.IsEmpty()) {
+    nsAutoString::const_iterator start, end;
+    attribute.BeginReading(start);
+    attribute.EndReading(end);
+    if (CaseInsensitiveFindInReadable(u"dblclick"_ns, start, end)) {
+      // Element has a jsaction double click handler
+      // See JB#56716 and https://github.com/google/jsaction
+      return true;
+    }
+  }
+
+  return false;
+}
+
 mozilla::ipc::IPCResult EmbedLiteViewChild::RecvHandleDoubleTap(const LayoutDevicePoint &aPoint,
                                                                 const Modifiers &aModifiers,
                                                                 const ScrollableLayerGuid &aGuid,
@@ -979,16 +1005,44 @@ mozilla::ipc::IPCResult EmbedLiteViewChild::RecvHandleDoubleTap(const LayoutDevi
   RefPtr<Document> document = presShell->GetDocument();
   NS_ENSURE_TRUE(document && !document->Fullscreen(), IPC_OK());
 
-  CSSRect zoomToRect = CalculateRectToZoomTo(document, cssPoint);
+  nsPoint offset;
+  nsCOMPtr<nsIWidget> widget = mHelper->GetWidget(&offset);
 
-  uint32_t presShellId;
-  ViewID viewId;
-  if (APZCCallbackHelper::GetOrCreateScrollIdentifiers(
-      document->GetDocumentElement(), &presShellId, &viewId)) {
-    ZoomToRect(presShellId, viewId, zoomToRect);
+  // Check whether the element is interested in double clicks
+  bool doubleclick = false;
+  if (sPostAZPCAsJson.doubleTap) {
+    WidgetMouseEvent hittest(true, eMouseHitTest, widget, WidgetMouseEvent::eReal);
+    hittest.mRefPoint = LayoutDeviceIntPoint::Truncate(aPoint);
+    hittest.mIgnoreRootScrollFrame = false;
+    hittest.mInputSource = MouseEvent_Binding::MOZ_SOURCE_TOUCH;
+    widget->DispatchInputEvent(&hittest);
+
+    if (EventTarget* target = hittest.GetDOMEventTarget()) {
+      if (nsCOMPtr<nsIContent> targetContent = do_QueryInterface(target)) {
+        // Check if the element or any parent element has a double click handler
+        for (Element* element = targetContent->GetAsElementOrParentElement();
+             element && !doubleclick; element = element->GetParentElement()) {
+          doubleclick = ElementSupportsDoubleClick(element);
+        }
+      }
+    }
   }
 
-  if (sPostAZPCAsJson.doubleTap) {
+  if (nsLayoutUtils::AllowZoomingForDocument(document) && !doubleclick) {
+    // Zoom in to/out from the double tapped element
+    CSSToLayoutDeviceScale scale(
+        presShell->GetPresContext()->CSSToDevPixelScale());
+    CSSPoint point = aPoint / scale;
+
+    CSSRect zoomToRect = CalculateRectToZoomTo(document, point);
+    uint32_t presShellId;
+    ViewID viewId;
+    if (APZCCallbackHelper::GetOrCreateScrollIdentifiers(
+        document->GetDocumentElement(), &presShellId, &viewId)) {
+      ZoomToRect(presShellId, viewId, zoomToRect);
+    }
+  } else {
+    // Pass the double tap on to the element
     nsString data;
     data.AppendPrintf("{ \"x\" : %f, \"y\" : %f }", cssPoint.x, cssPoint.y);
     mHelper->DispatchMessageManagerMessage(NS_LITERAL_STRING("Gesture:DoubleTap"), data);

--- a/embedding/embedlite/embedthread/EmbedContentController.cpp
+++ b/embedding/embedlite/embedthread/EmbedContentController.cpp
@@ -59,14 +59,14 @@ void EmbedContentController::HandleTap(TapType aType, const LayoutDevicePoint &a
     case GeckoContentController::TapType::eSingleTap:
       HandleSingleTap(aPoint, aModifiers, aGuid, aInputBlockId);
       break;
+    case GeckoContentController::TapType::eSecondTap:
+      [[fallthrough]];
     case GeckoContentController::TapType::eDoubleTap:
       HandleDoubleTap(aPoint, aModifiers, aGuid, aInputBlockId);
       break;
     case GeckoContentController::TapType::eLongTap:
       HandleLongTap(aPoint, aModifiers, aGuid, aInputBlockId);
       break;
-    case GeckoContentController::TapType::eSecondTap:
-      [[fallthrough]];
     case GeckoContentController::TapType::eLongTapUp:
       break;
   }


### PR DESCRIPTION
Ensure that double taps are passed on to the embedhelper.js, so they can be passed on to any javascript handlers.

Set the decision about whether to zoom on double tap follow the decision made by nsLayoutUtils::AllowZoomingForDocument().