### PR TITLE
[sailfishos][gecko] Do not remove debugging symbols

### DIFF
--- a/rpm/0090-sailfishos-gecko-Disable-debug-info-for-rust.patch
+++ b/rpm/0090-sailfishos-gecko-Disable-debug-info-for-rust.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Denis Grigorev <d.grigorev@omprussia.ru>
+Date: Thu, 16 Dec 2021 19:26:27 +0300
+Subject: [PATCH] [sailfishos][gecko] Disable debug info for rust
+
+---
+ build/moz.configure/toolchain.configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/moz.configure/toolchain.configure b/build/moz.configure/toolchain.configure
+index 5ef6e31089b4..520ecc776e86 100755
+--- a/build/moz.configure/toolchain.configure
++++ b/build/moz.configure/toolchain.configure
+@@ -1898,7 +1898,7 @@ def rust_compile_flags(opt_level, debug_rust, debug_symbols, frame_pointers):
+         debug_assertions = False
+ 
+     if debug_symbols:
+-        debug_info = '2'
++        debug_info = '0'
+ 
+     opts = []
+ 
+-- 
+2.17.1
+

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -20,8 +20,8 @@
 %define system_libwebp      1
 
 
-%global mozappdir     %{_libdir}/%{name}-%{milestone}
-%global mozappdirdev  %{_libdir}/%{name}-devel-%{milestone}
+%global mozappdir     %{_libdir}/%{name}-%{greversion}
+%global mozappdirdev  %{_libdir}/%{name}-devel-%{greversion}
 
 # Private/bundled libs the final package should not provide or depend on.
 %global privlibs             libfreebl3
@@ -144,6 +144,7 @@ Patch86:    0086-sailfishos-gecko-Add-preference-to-bypass-CORS-on-ns.patch
 Patch87:    0087-sailfishos-gecko-Fix-memory-reporting-of-wasm-memory.patch
 Patch88:    0088-Revert-Bug-1611386-Drop-support-for-enable-system-sq.patch
 Patch89:    0089-sailfishos-gecko-Add-a-video-decoder-based-on-gecko-.patch
+Patch90:    0090-sailfishos-gecko-Disable-debug-info-for-rust.patch
 
 #Patch20:    0020-sailfishos-loginmanager-Adapt-LoginManager-to-EmbedL.patch
 #Patch51:    0051-sailfishos-gecko-Remove-android-define-from-logging.patch
@@ -449,7 +450,7 @@ echo "ac_add_options --disable-elf-hack" >> "$MOZCONFIG"
 # Additionally we limit the memory usage during linking
 %ifarch %arm32 %arm64
 # Garbage collect on arm to reduce memory requirements, JB#55074
-echo 'FIX_LDFLAGS="-Wl,--strip-debug -Wl,--gc-sections -Wl,--reduce-memory-overheads -Wl,--no-keep-memory -Wl,-rpath=%{mozappdir}"' >> "${MOZCONFIG}"
+echo 'FIX_LDFLAGS="-Wl,--gc-sections -Wl,--reduce-memory-overheads -Wl,--no-keep-memory -Wl,-rpath=%{mozappdir}"' >> "${MOZCONFIG}"
 %else
 echo 'FIX_LDFLAGS="-Wl,--reduce-memory-overheads -Wl,--no-keep-memory -Wl,-rpath=%{mozappdir}"' >> "${MOZCONFIG}"
 %endif


### PR DESCRIPTION
This patch disables the generation of debug information for rust and
returns the contents of the debuginfo package.

Add 'a' character to the milestone in rpm/xulrunner-qt5.spec to build
an alpha version of the engine.