### PR TITLE
Remove setting special viewport in desktop mode. JB#57542

### DIFF
--- a/rpm/0091-sailfishos-gecko-removed-special-desktop-viewport.patch
+++ b/rpm/0091-sailfishos-gecko-removed-special-desktop-viewport.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: andrew-korolev-omp <a.korolev@omp.ru>
+Date: Fri, 25 Feb 2022 14:54:47 +0300
+Subject: [PATCH] removed setting special viewport in desktop mode
+
+---
+ dom/base/Document.cpp | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/dom/base/Document.cpp b/dom/base/Document.cpp
+index 132c0ecbfdac..5ad2078ea506 100644
+--- a/dom/base/Document.cpp
++++ b/dom/base/Document.cpp
+@@ -9515,20 +9515,6 @@ nsViewportInfo Document::GetViewportInfo(const ScreenIntSize& aDisplaySize) {
+   CSSToScreenScale defaultScale =
+       layoutDeviceScale * LayoutDeviceToScreenScale(1.0);
+ 
+-  // Special behaviour for desktop mode, provided we are not on an about: page
+-  nsPIDOMWindowOuter* win = GetWindow();
+-  if (win && win->IsDesktopModeViewport() && !IsAboutPage()) {
+-    CSSCoord viewportWidth =
+-        StaticPrefs::browser_viewport_desktopWidth() / fullZoom;
+-    CSSToScreenScale scaleToFit(aDisplaySize.width / viewportWidth);
+-    float aspectRatio = (float)aDisplaySize.height / aDisplaySize.width;
+-    CSSSize viewportSize(viewportWidth, viewportWidth * aspectRatio);
+-    ScreenIntSize fakeDesktopSize = RoundedToInt(viewportSize * scaleToFit);
+-    return nsViewportInfo(fakeDesktopSize, scaleToFit,
+-                          nsViewportInfo::ZoomFlag::AllowZoom,
+-                          nsViewportInfo::ZoomBehaviour::Mobile);
+-  }
+-
+   if (!nsLayoutUtils::ShouldHandleMetaViewport(this)) {
+     return nsViewportInfo(aDisplaySize, defaultScale,
+                           nsLayoutUtils::AllowZoomingForDocument(this)
+-- 
+2.25.1
+

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -145,6 +145,7 @@ Patch87:    0087-sailfishos-gecko-Fix-memory-reporting-of-wasm-memory.patch
 Patch88:    0088-Revert-Bug-1611386-Drop-support-for-enable-system-sq.patch
 Patch89:    0089-sailfishos-gecko-Add-a-video-decoder-based-on-gecko-.patch
 Patch90:    0090-sailfishos-gecko-Disable-debug-info-for-rust.patch
+Patch91:    0091-sailfishos-gecko-removed-special-desktop-viewport.patch
 
 #Patch20:    0020-sailfishos-loginmanager-Adapt-LoginManager-to-EmbedL.patch
 #Patch51:    0051-sailfishos-gecko-Remove-android-define-from-logging.patch


### PR DESCRIPTION
This is a part of fixes for JB#57542, another part you can find here: https://github.com/sailfishos/sailfish-components-webview/pull/153
As for this part, we found that when switching to desktop mode gecko changes its viewport to a value that corresponds the DevicePixelRatio (DPR) value of ~2.1, regardless of what the DPI value of screen is. In the other part of fixes we implemented mechanism that calculates DPR value depending of screen DPI, and for example for 1920x1200 10 inch screen the DPR value will be 1.5. So, after we switch to desktop mode, the DPR value increases to ~2.1 and the elements on the page become bigger, than in mobile version. But many desktop web-pages are designed, on the contrary, for lower DPI values (on desktop it is usually 1.0) and smaller element size. So we suggest to stick to the middle option and leave the DPR and viewport unchanged when switching to desktop mode, so as our colleagues from Yandex browser for Android (100M+ installs) do.