### PR TITLE
[sailfishos][embedlite] Add a content controller stack. Fixes JB#57690

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -101,6 +101,10 @@ EmbedLiteView::SetIsActive(bool aIsActive)
   Unused << mViewParent->SendSetIsActive(aIsActive);
   // Make sure active view content controller is always registered with
   // APZCTreeManager for the window.
+
+  NS_ENSURE_TRUE(mViewImpl, );
+  mViewImpl->SetIsActive(aIsActive);
+
   if (aIsActive) {
     static_cast<EmbedLiteViewParent*>(mViewParent)->UpdateScrollController();
   }

--- a/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
+++ b/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
@@ -40,4 +40,5 @@ interface EmbedLiteViewIface : nsISupports
     void ViewAPIDestroyed();
     void GetUniqueID(out uint32_t aId);
     void SetEmbedAPIView(in EmbedLiteView aView);
+    void SetIsActive(in bool aIsActive);
 };

--- a/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
@@ -67,6 +67,10 @@ EmbedLiteViewParent::~EmbedLiteViewParent()
 {
   MOZ_COUNT_DTOR(EmbedLiteViewParent);
   LOGT("mView:%p, mCompositor:%p", mView, mCompositor.get());
+  nsWindow *window = GetWindowWidget();
+  if (window) {
+    window->Deactivate(mContentController);
+  }
   mContentController = nullptr;
   mWindow.RemoveObserver(this);
 }
@@ -75,6 +79,10 @@ void
 EmbedLiteViewParent::ActorDestroy(ActorDestroyReason aWhy)
 {
   LOGT("reason: %i", aWhy);
+  nsWindow *window = GetWindowWidget();
+  if (window) {
+    window->Deactivate(mContentController);
+  }
   mContentController = nullptr;
 }
 
@@ -101,7 +109,7 @@ EmbedLiteViewParent::UpdateScrollController()
 
     nsWindow *window = GetWindowWidget();
     if (window) {
-      window->SetContentController(mContentController);
+      window->Activate(mContentController);
     }
   }
 }
@@ -639,6 +647,24 @@ EmbedLiteViewParent::SetEmbedAPIView(EmbedLiteView *aView)
 {
   LOGT();
   mView = aView;
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+EmbedLiteViewParent::SetIsActive(bool aIsActive)
+{
+  nsWindow *window = GetWindowWidget();
+
+  if (window) {
+    if (aIsActive) {
+      if (mCompositor) {
+        window->Activate(mContentController);
+      }
+    } else {
+      window->Deactivate(mContentController);
+    }
+  }
+
   return NS_OK;
 }
 

--- a/embedding/embedlite/embedshared/nsWindow.h
+++ b/embedding/embedlite/embedshared/nsWindow.h
@@ -11,6 +11,7 @@
 #include "PuppetWidgetBase.h"
 
 #include "mozilla/WidgetUtils.h"           // for InputContext
+#include <list>
 
 namespace mozilla {
 
@@ -22,6 +23,7 @@ namespace embedlite {
 
 class EmbedLiteWindowChild;
 class EmbedLiteWindowListener;
+class EmbedContentController;
 
 class nsWindow : public PuppetWidgetBase
 {
@@ -88,7 +90,8 @@ public:
   uint32_t GetUniqueID() const;
   layers::LayersId GetRootLayerId() const;
 
-  void SetContentController(mozilla::layers::GeckoContentController* aController);
+  void Activate(EmbedContentController* aController);
+  void Deactivate(EmbedContentController* aController);
   RefPtr<mozilla::layers::IAPZCTreeManager> GetAPZCTreeManager();
   void SetFirstViewCreated() { mFirstViewCreated = true; }
   bool IsFirstViewCreated() const { return mFirstViewCreated; }
@@ -116,6 +119,9 @@ private:
   bool mFirstViewCreated;
   EmbedLiteWindowChild* mWindow; // Not owned, can be null.
   InputContext mInputContext;
+
+  typedef std::list<EmbedContentController *> ControllerList;
+  ControllerList mControllers;
 
   friend already_AddRefed<nsIWidget> nsIWidget::CreateTopLevelWindow();
   friend already_AddRefed<nsIWidget> nsIWidget::CreateChildWindow();

--- a/embedding/embedlite/embedthread/EmbedContentController.cpp
+++ b/embedding/embedlite/embedthread/EmbedContentController.cpp
@@ -283,3 +283,12 @@ void EmbedContentController::DispatchToRepaintThread(already_AddRefed<Runnable> 
 {
   mUILoop->PostTask(std::move(aTask));
 }
+
+uint32_t EmbedContentController::GetUniqueID() const
+{
+  uint32_t id = 0;
+  if (mRenderFrame) {
+    mRenderFrame->GetUniqueID(& id);
+  }
+  return id;
+}

--- a/embedding/embedlite/embedthread/EmbedContentController.h
+++ b/embedding/embedlite/embedthread/EmbedContentController.h
@@ -63,6 +63,7 @@ public:
   virtual void CancelAutoscroll(const ScrollableLayerGuid& aGuid) override;
 
   virtual void DispatchToRepaintThread(already_AddRefed<Runnable> aTask) override;
+  uint32_t GetUniqueID() const;
 
 private:
   EmbedLiteViewListener *GetListener() const;


### PR DESCRIPTION
When multiple WebView componennts are used in an app, since there is
only one compositor, only one can be in direct use at a time. This will
be the last that was set as active.

When the currently activated component is deactivated, the WebView that
was active prior to that should be reinstanted. In particular, the
view's GeckoContentController needs to be reinstated.

This change adds a stack for managing the content controllers, so that
previously active controllers can be reactivated.