### PR TITLE
[sailfishos][embedlite] Drop radio and checkbox max size restriction. Fixes JB#57693

### DIFF
--- a/embedding/embedlite/tests/content/embedScrollStyles.css
+++ b/embedding/embedlite/tests/content/embedScrollStyles.css
@@ -171,8 +171,6 @@ button {
 
 input[type="radio"],
 input[type="checkbox"] {
-  max-width: 14px;
-  max-height: 14px;
   border: 1px solid #a7a7a7 !important;
   padding: 2px 1px 2px 1px;
 }


### PR DESCRIPTION
Remove the restriction on the maximum size of radio and checkbox input elements, so that they can be made larger than the default.

This is to match the behaviour of desktop and Android Firefox.

In particular, this fixes a but that prevented [Material toggle button components](https://material-components.github.io/material-web/demos/switch) from working correctly.