### PR TITLE
[sailfishos][embedlite] Clean background gradients from input elements. Fixes JB#58457

### DIFF
--- a/embedding/embedlite/tests/content/embedScrollStyles.css
+++ b/embedding/embedlite/tests/content/embedScrollStyles.css
@@ -110,7 +110,7 @@ textarea,
   border-style: solid;
   border-color: #7d7d7d;
   color: #414141;
-  background: white linear-gradient(rgba(115,115,115,0.5) 0, rgba(215,215,215,0.5) 3px, rgba(255,255,255,0.2) 16px);
+  background: initial;
 }
 
 /* Selects are handled by the form helper, see bug 685197 */
@@ -128,15 +128,15 @@ button {
   border-style: solid;
   border-color: #7d7d7d;
   color: #414141;
-  background: white linear-gradient(rgba(255,255,255,0.2) 0, rgba(215,215,215,0.5) 18px, rgba(115,115,115,0.5) 100%);
+  background: initial;
 }
 
 input[type="checkbox"] {
-  background: white linear-gradient(rgba(115,115,115,0.5) 0, rgba(215,215,215,0.5) 2px, rgba(255,255,255,0.2) 6px);
+  background: initial;
 }
 
 input[type="radio"] {
-  background: radial-gradient(at 6px 6px, rgba(255,255,255,0.2) 3px, rgba(195,195,195,0.5) 5px, rgba(115,115,115,0.5) 100%);
+  background: initial;
 }
 
 select {
@@ -202,7 +202,7 @@ input[type="file"]:focus > input[type="text"],
   outline: 0px !important;
   border-style: solid;
   border-color: rgb(94,128,153);
-  background: white linear-gradient(rgba(27,113,177,0.5) 0, rgba(198,225,246,0.2) 3px, rgba(255,255,255,0.2) 16px);
+  background: initial;
 }
 
 select:not([size]):not([multiple]):focus,
@@ -215,7 +215,7 @@ button:focus {
   outline: 0px !important;
   border-style: solid;
   border-color: rgb(94,128,153);
-  background: white linear-gradient(rgba(255,255,255,0.2) 0, rgba(198,225,256,0.2) 18px, rgba(27,113,177,0.5) 100%);
+  background: initial;
 }
 
 input[type="checkbox"]:focus,
@@ -224,11 +224,11 @@ input[type="radio"]:focus {
 }
 
 input[type="checkbox"]:focus {
-  background: white linear-gradient(rgba(27,113,177,0.5) 0, rgba(198,225,246,0.2) 2px, rgba(255,255,255,0.2) 6px);
+  background: initial;
 }
 
 input[type="radio"]:focus {
-  background: radial-gradient(at 6px 6px, rgba(255,255,255,0.2) 3px, rgba(198,225,246,0.2) 5px, rgba(27,113,177,0.5) 100%);
+  background: initial;
 }
 
 /* we need to be specific for selects because the above rules are specific too */
@@ -245,13 +245,13 @@ button[disabled],
   border-color: rgba(125,125,125,0.4);
   border-style: solid;
   border-width: 1px;
-  background: transparent linear-gradient(rgba(185,185,185,0.4) 0, rgba(235,235,235,0.4) 3px, rgba(255,255,255,0.4) 100%);
+  background: initial;
 }
 
 select:not([size]):not([multiple])[disabled],
 select[size="0"][disabled],
 select[size="1"][disabled] {
-  background: transparent linear-gradient(rgba(255,255,255,0.4) 0, rgba(235,235,235,0.4) 3px, rgba(185,185,185,0.4) 100%);
+  background: initial;
 }
 
 input[type="button"][disabled],
@@ -259,7 +259,7 @@ input[type="submit"][disabled],
 input[type="reset"][disabled],
 button[disabled="true"] {
   padding: 0 7px 0 7px;
-  background: transparent linear-gradient(rgba(255,255,255,0.4) 0, rgba(235,235,235,0.4) 3px, rgba(185,185,185,0.4) 100%);
+  background: initial;
 }
 
 input[type="radio"][disabled],


### PR DESCRIPTION
This covers textarea, input, select, and button.

Instructions regarding [omni debugging](https://docs.sailfishos.org/Reference/Core_Areas_and_APIs/Browser/Working_with_Browser/#debugging-omnija-of-gecko) helps when testing this.
