### PR TITLE
[sailfishos][gecko] Add support for prefers-color-scheme. JB#58394

### DIFF
--- a/rpm/0093-sailfishos-gecko-Add-support-for-prefers-color-schem.patch
+++ b/rpm/0093-sailfishos-gecko-Add-support-for-prefers-color-schem.patch
@@ -1,0 +1,154 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
+Date: Wed, 23 Nov 2022 09:08:22 +0200
+Subject: [PATCH] [sailfishos][gecko] Add support for prefers-color-scheme.
+ JB#58394
+
+Adds support to qt/nsLookAndFeel for the prefers-color-scheme media tag.
+The renderer already supports it by setting the ui.systemUsesDarkTheme
+preference to 0 or 1.
+
+This patch allows, in addition, for the colour scheme to be controlled
+by sending a "ambience-theme-changed" notification with a data payload
+of either "light" or "dark". If the ui.systemUsesDarkTheme preference is
+unset or set to something other than 0 or 1, the notification value will
+be used to control the theme instead.
+
+This functionality is used to update the colour scheme based on the
+ambience of the device.
+---
+ widget/qt/nsLookAndFeel.cpp | 71 ++++++++++++++++++++++++++++++++++++-
+ widget/qt/nsLookAndFeel.h   |  4 +++
+ 2 files changed, 74 insertions(+), 1 deletion(-)
+
+diff --git a/widget/qt/nsLookAndFeel.cpp b/widget/qt/nsLookAndFeel.cpp
+index 6a0f91d1cd87..495b25e057ec 100644
+--- a/widget/qt/nsLookAndFeel.cpp
++++ b/widget/qt/nsLookAndFeel.cpp
+@@ -26,6 +26,33 @@
+ #include "mozilla/gfx/2D.h"
+ #include "mozilla/FontPropertyTypes.h"
+ #include "mozilla/StaticPrefs_widget.h"
++#include "mozilla/Services.h"
++#include "mozilla/Logging.h"
++#include "nsIObserver.h"
++
++using namespace mozilla;
++
++LazyLogModule sLookAndFeel("LookAndFeel");
++
++class nsLookAndFeel::Observer final : public nsIObserver
++{
++public:
++    NS_DECL_ISUPPORTS
++
++    explicit Observer() : mDarkAmbience(false) {}
++
++    NS_IMETHOD Observe(nsISupports*, const char* aTopic,
++                       const char16_t* aData) override;
++
++    bool GetDarkAmbience();
++private:
++    virtual ~Observer() = default;
++
++public:
++    bool mDarkAmbience;
++};
++
++NS_IMPL_ISUPPORTS(nsLookAndFeel::Observer, nsIObserver)
+ 
+ static const char16_t UNICODE_BULLET = 0x2022;
+ 
+@@ -35,12 +62,48 @@ static const char16_t UNICODE_BULLET = 0x2022;
+ nsLookAndFeel::nsLookAndFeel()
+     : nsXPLookAndFeel()
+ {
++    mObserver = new nsLookAndFeel::Observer();
++    nsCOMPtr<nsIObserverService> os = mozilla::services::GetObserverService();
++    if (os) {
++        os->AddObserver(mObserver, "ambience-theme-changed", false);
++    }
+ }
+ 
+ nsLookAndFeel::~nsLookAndFeel()
+ {
++    nsCOMPtr<nsIObserverService> os = mozilla::services::GetObserverService();
++    if (os) {
++        os->RemoveObserver(mObserver, "ambience-theme-changed");
++    }
++    mObserver = nullptr;
++}
++
++NS_IMETHODIMP nsLookAndFeel::Observer::Observe(nsISupports*, const char* aTopic, const char16_t* aData) {
++    MOZ_ASSERT(!strcmp(aTopic, "ambience-theme-changed"));
++
++    bool darkAmbience = false;
++    nsDependentString data(aData);
++    if (data.EqualsLiteral("dark")) {
++        darkAmbience = true;
++    }
++
++    if (mDarkAmbience != darkAmbience) {
++        mDarkAmbience = darkAmbience;
++        MOZ_LOG(sLookAndFeel, LogLevel::Info, ("Ambience set to %s", mDarkAmbience ? "dark" : "light"));
++        if (nsCOMPtr<nsIObserverService> obs = services::GetObserverService()) {
++            obs->NotifyObservers(nullptr, "look-and-feel-changed", nullptr);
++        }
++    }
++
++    return NS_OK;
++}
++
++bool nsLookAndFeel::Observer::GetDarkAmbience()
++{
++    return mDarkAmbience;
+ }
+ 
++
+ void nsLookAndFeel::NativeInit() { }
+ 
+ nsresult
+@@ -304,7 +367,8 @@ nsresult
+ nsLookAndFeel::GetIntImpl(IntID aID, int32_t &aResult)
+ {
+     nsresult rv = nsXPLookAndFeel::GetIntImpl(aID, aResult);
+-    if (NS_SUCCEEDED(rv))
++    // Make an exception for eIntID_SystemUsesDarkTheme as this is handled below
++    if (NS_SUCCEEDED(rv) && ((aID != eIntID_SystemUsesDarkTheme) || (aResult != 2)))
+         return rv;
+ 
+     rv = NS_OK;
+@@ -383,6 +447,11 @@ nsLookAndFeel::GetIntImpl(IntID aID, int32_t &aResult)
+             aResult = 2;
+             break;
+ 
++        case eIntID_SystemUsesDarkTheme:
++            // Choose theme based on ambience
++            aResult = mObserver->GetDarkAmbience() ? 1 : 0;
++            break;
++
+         default:
+             aResult = 0;
+             rv = NS_ERROR_FAILURE;
+diff --git a/widget/qt/nsLookAndFeel.h b/widget/qt/nsLookAndFeel.h
+index e8a134b93f3f..c9982e45c7ab 100644
+--- a/widget/qt/nsLookAndFeel.h
++++ b/widget/qt/nsLookAndFeel.h
+@@ -21,6 +21,7 @@
+ 
+ class nsLookAndFeel : public nsXPLookAndFeel
+ {
++    class Observer;
+ public:
+     nsLookAndFeel();
+     virtual ~nsLookAndFeel();
+@@ -36,6 +37,9 @@ public:
+ 
+ protected:
+     virtual nsresult NativeGetColor(ColorID aID, nscolor &aColor) override;
++
++private:
++    RefPtr<Observer> mObserver;
+ };
+ 
+ #endif

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -147,6 +147,7 @@ Patch89:    0089-sailfishos-gecko-Add-a-video-decoder-based-on-gecko-.patch
 Patch90:    0090-sailfishos-gecko-Disable-debug-info-for-rust.patch
 Patch91:    0091-sailfishos-gecko-Initialise-SVGGeometryProperty-Reso.patch
 Patch92:    0092-sailfishos-build-Add-support-for-aarch64-to-elfhack..patch
+Patch93:    0093-sailfishos-gecko-Add-support-for-prefers-color-schem.patch
 
 #Patch20:    0020-sailfishos-loginmanager-Adapt-LoginManager-to-EmbedL.patch
 #Patch51:    0051-sailfishos-gecko-Remove-android-define-from-logging.patch


### PR DESCRIPTION
Adds support to qt/nsLookAndFeel for the prefers-color-scheme media tag. The renderer already supports it by setting the ui.systemUsesDarkTheme preference to 0 or 1.

This patch allows, in addition, for the colour scheme to be controlled by sending an "ambience-theme-changed" notification with a data payload of either "light" or "dark". If the ui.systemUsesDarkTheme preference is unset or set to 2, the notification value will be used to control the theme instead.

This functionality is used to update the colour scheme based on the ambience of the device.