### PR TITLE
WIP: [rpm] After fixing scratchbox the libclang workaround is not required anymore. JB#55042

### DIFF
--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -353,19 +353,16 @@ source "%BUILD_DIR"/rpm-shared.env
 # hack for when not using virtualenv
 ln -sf "%BUILD_DIR"/config.status $PWD/build/config.status
 
-%ifarch %arm32 %arm64
-# Make stdc++ headers available on a fresh path to work around include_next bug JB#55058
-if [ ! -L "%BUILD_DIR"/include ] ; then ln -s /usr/include/c++/8.3.0/ "%BUILD_DIR"/include; fi
-
-# Expose the elf32-i386 libclang.so.10 for use inside the arm target, JB#55042
-mkdir -p "%BUILD_DIR"/lib
-SBOX_DISABLE_MAPPING=1 cp /usr/lib/libclang.so.10 "%BUILD_DIR"/lib/libclang.so.10
-echo "ac_add_options --with-libclang-path='"%BUILD_DIR"/lib/'" >> "$MOZCONFIG"
+%ifarch %arm64
+echo "ac_add_options --with-libclang-path='/usr/lib64/'" >> "$MOZCONFIG"
+%endif
+%ifarch %arm32
+echo "ac_add_options --with-libclang-path='/usr/lib/'" >> "$MOZCONFIG"
+%endif
 
 # Do not build as thumb since it breaks video decoding.
 %ifarch %arm32
 echo "ac_add_options --with-thumb=no" >> "$MOZCONFIG"
-%endif
 %endif
 
 echo "mk_add_options MOZ_OBJDIR='%BUILD_DIR'" >> "$MOZCONFIG"


### PR DESCRIPTION
We still need to specify the path for it though, since configure picks it off of LD_LIBRARY_PATH which has the sb2 tooling path in it.

DO NOT MERGE BEFORE:
https://github.com/sailfishos/scratchbox2/pull/21