### PR TITLE
[sailfishos][embedlite] Cleanup float preferences. JB#62618

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -59,8 +59,8 @@ pref("gfx.vsync.compositor.unobserve-count", 40);
 
 // APZC preferences.
 pref("apz.allow_zooming", true);
-pref("apz.fling_accel_base_mult", "1.125f");
-pref("apz.min_skate_speed", "1.0f");
+pref("apz.fling_accel_base_mult", "1.125");
+pref("apz.min_skate_speed", "1.0");
 
 // Gaia relies heavily on scroll events for now, so lets fire them
 // more often than the default value (100).


### PR DESCRIPTION
It seems that "0.1f" value is no longer getting through as a float like it used to. The all.js of gecko-dev confirms this as there are no longer f-suffixed floats.

This commit cleans f-suffixed float prefs from embedding.js.

GitHub issue:
https://github.com/sailfishos/sailfish-browser/issues/1038