### PR TITLE
EmbedLite css default value fixes

### DIFF
--- a/embedding/embedlite/tests/content/embedScrollStyles.css
+++ b/embedding/embedlite/tests/content/embedScrollStyles.css
@@ -5,6 +5,12 @@
 @namespace url("http://www.w3.org/1999/xhtml");
 @namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
+html,
+body {
+    font-family: sans-serif;
+    -moz-text-size-adjust: none;
+}
+
 /* Style the scrollbars */
 xul|window xul|scrollbar {
   display: none;

--- a/embedding/embedlite/tests/content/embedScrollStyles.css
+++ b/embedding/embedlite/tests/content/embedScrollStyles.css
@@ -7,6 +7,8 @@
 
 html,
 body {
+    margin: 0;
+    padding: 0;
     font-family: sans-serif;
     -moz-text-size-adjust: none;
 }


### PR DESCRIPTION
This PR contains two commits. Both commits touches html and body default css values:

- First one fixes default font to sans-serif
- Second one margin & padding to zero

Changes are synchronized from Android FF 91 https://github.com/sailfishos-mirror/gecko-dev/blob/78d17b06b04f2b76bcb6e3e2a553f4ad0202bc8d/mobile/android/themes/geckoview/config.css

To be noted that these were broken on ESR 78 as well.

GitHub issue:
https://github.com/sailfishos/sailfish-browser/issues/1083
https://github.com/sailfishos/sailfish-browser/issues/1084