### PR TITLE
[sailfishos][gecko] Clear up message pump ownership. JB#62818

### DIFF
--- a/embedding/embedlite/EmbedLiteApp.cpp
+++ b/embedding/embedlite/EmbedLiteApp.cpp
@@ -377,7 +377,7 @@ EmbedLiteApp::Shutdown()
 
   mUILoop->DoQuit();
 
-  if (mIsAsyncLoop) {
+  if (!mIsAsyncLoop) {
     delete mUILoop;
     mUILoop = nullptr;
   }

--- a/embedding/embedlite/EmbedLiteMessagePump.cpp
+++ b/embedding/embedlite/EmbedLiteMessagePump.cpp
@@ -98,6 +98,7 @@ private:
 EmbedLiteMessagePump::EmbedLiteMessagePump(EmbedLiteMessagePumpListener* aListener)
   : mListener(aListener)
   , mEmbedPump(new MessagePumpEmbed(aListener))
+  , mOwnerLoop(nullptr)
 {
   if (aListener) {
     mOwnerLoop = new EmbedLiteUILoop(this);
@@ -108,6 +109,7 @@ EmbedLiteMessagePump::EmbedLiteMessagePump(EmbedLiteMessagePumpListener* aListen
 
 EmbedLiteMessagePump::~EmbedLiteMessagePump()
 {
+  delete mOwnerLoop;
 }
 
 base::MessagePump*


### PR DESCRIPTION
EmbedLiteApp deleted the ui loop specifically in the case where it hadn't created one, which seems like reversed logic.

Also if EmbedLiteMessagePump creates a loop and holds it, could expect it to also delete it.