### PR TITLE
Include missing default settings dumps. JB#63884

### DIFF
--- a/embedding/embedlite/installer/package-manifest.in
+++ b/embedding/embedlite/installer/package-manifest.in
@@ -63,9 +63,6 @@
 ; [Base Browser Files]
 @BINPATH@/application.ini
 @BINPATH@/platform.ini
-@BINPATH@/defaults/settings/blocklists/addons.json
-; TODO bug 1639050: addons-bloomfilters should be used instead of addons.json
-@BINPATH@/defaults/settings/security-state/onecrl.json
 
 ; [Components]
 ; JavaScript components
@@ -108,6 +105,8 @@
 @BINPATH@/greprefs.js
 @BINPATH@/defaults/autoconfig/prefcalls.js
 @BINPATH@/defaults/pref/embedding.js
+; Remote Settings JSON dumps
+@BINPATH@/defaults/settings
 
 ; [Layout Engine Resources]
 ; Style Sheets, Graphics and other Resources used by the layout engine.


### PR DESCRIPTION
Things like search service initialization breaks, if the remote settings fetcher fails and there are no local defaults available.