### PR TITLE
Update feature enabler preferences for ESR115

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -352,9 +352,6 @@ pref("plugins.click_to_play", true);
 // The default value for nsIPluginTag.enabledState (STATE_CLICKTOPLAY = 1)
 pref("plugin.default.state", 1);
 
-pref("notification.feature.enabled", true);
-pref("dom.webnotifications.enabled", true);
-
 // prevent tooltips from showing up
 pref("browser.chrome.toolbar_tips", false);
 pref("dom.indexedDB.warningQuota", 5);
@@ -445,9 +442,6 @@ pref("security.OCSP.enabled", 2);
 // The audio backend, see cubeb_init && CubebUtils.cpp (sCubebBackendName)
 pref("media.cubeb.backend", "pulse");
 
-// On ESR60 customelements is only enabled for nightly. Enable for us.
-pref("dom.webcomponents.customelements.enabled", true);
-
 // Enable serviceworkers
 pref("dom.serviceWorkers.enabled", true);
 
@@ -463,11 +457,11 @@ pref("media.webrtc.hw.h264.enabled", true);
 // until the bug is fixed.
 pref("media.peerconnection.video.vp9_enabled", false);
 
-// Enable the Visual Viewport API
-pref("dom.visualviewport.enabled", true);
-
 // Use the platform decoder for VPX-encoded video during a WebRTC call
 pref("media.navigator.mediadatadecoder_vpx_enabled", true);
 
-// Support for the dialog element.
-pref("dom.dialog_element.enabled", true);
+// Enable CSS nesting - comes standard in 117+
+pref("layout.css.nesting.enabled", true);
+
+// Enable CSS has() selectors - comes standard in 121+
+pref("layout.css.has-selector.enabled", true);


### PR DESCRIPTION
Drop things that now come standard.
Add CSS nesting and has() selectors.

----
Added enablers as suggested here:
https://www.reddit.com/r/firefox/comments/1rqg03o/firefox_esr_115_updates_has_been_extended_to/

I have not been able to test this - so please check a running ESR115 browser.

notification.feature.enabled: Not found in StaticPrefs.yaml, probably old and removed.
dom.webnotifications.enabled: now defaults to true.

Custom elements is now standard - the specific enabler is mentioned to only be needed until 62:
https://caniuse.com/custom-elementsv1
dom.webcomponents.customelements.enabled now defaults to true in StaticPrefs.yaml.

Visual viewport is now standard - but the specific enabler is not mentioned:
https://caniuse.com/?search=visualviewport
dom.visualviewport.enabled now defaults to true in StaticPrefs.yaml.

Dialog is now standard - the specific enabler is mentioned to only be needed until 97:
https://caniuse.com/dialog
dom.dialog_element.enabled now defaults to true in StaticPrefs.yaml.