### PR TITLE
Unify Qt EGL display handling and fix AV1 playback

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -374,6 +374,8 @@ pref("media.cache_readahead_limit", 30);
 pref("media.video-queue.default-size", 3);
 
 // Use Gecko/FFmpeg/gecko-camera media paths; gmp-droid is no longer shipped.
+// EmbedLite has no remote RDD decoder path; decode supported formats locally.
+pref("media.rdd-process.enabled", false);
 pref("media.gmp.decoder.enabled", false);
 pref("media.decoder.recycle.enabled", true);
 

--- a/rpm/0085-Support-Qt-EGL-display-on-Mesa.patch
+++ b/rpm/0085-Support-Qt-EGL-display-on-Mesa.patch
@@ -1,0 +1,479 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Branson <andrew.branson@jolla.com>
+Date: Wed, 22 Jul 2026 16:05:47 +0200
+Subject: [sailfishos][egl] Support Qt's EGL display on Mesa
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Qt's Wayland platform plugin owns the EGLDisplay used for its native
+windows. Borrow that initialized display in Gecko so Mesa does not create a
+second Wayland connection, and leave initialization and termination to Qt.
+
+Request EGL configs whose renderable type matches the desktop GL, GLES 2, or
+GLES 3 context Gecko is about to create. This avoids EGL_BAD_MATCH when
+hardware WebRender requests a GLES 3 context.
+
+Allow desktop GL contexts to create EGLImage shared surfaces without
+requiring GLES-only GL_OES_EGL_image extensions. The EGL KHR image
+extensions provide the producer operation used on Mesa.
+
+Co-authored-by: Adam Pigg <adam@piggz.co.uk>
+Co-authored-by: David Llewellyn-Jones <david.llewellyn-jones@jolla.com>
+Co-authored-by: Frajo Haider <franz.haider@jolla.com>
+Co-authored-by: Matti Lehtimäki <matti.lehtimaki@jolla.com>
+---
+ gfx/gl/AndroidSurfaceTexture.cpp |  2 +-
+ gfx/gl/GLContextEGL.h            |  1 +
+ gfx/gl/GLContextProviderEGL.cpp  | 93 +++++++++++++++++++++++++-------
+ gfx/gl/GLLibraryEGL.cpp          | 50 ++++++++++++-----
+ gfx/gl/GLLibraryEGL.h            | 12 +++--
+ gfx/gl/SharedSurfaceEGL.cpp      |  3 +-
+ gfx/gl/moz.build                 |  3 ++
+ 7 files changed, 126 insertions(+), 38 deletions(-)
+
+diff --git a/gfx/gl/AndroidSurfaceTexture.cpp b/gfx/gl/AndroidSurfaceTexture.cpp
+index 30260efe32adf..d313b0527c85d 100644
+--- a/gfx/gl/AndroidSurfaceTexture.cpp
++++ b/gfx/gl/AndroidSurfaceTexture.cpp
+@@ -82,7 +82,7 @@ class AndroidSharedBlitGL final {
+     const auto egl = gl::DefaultEglDisplay(&ignored);
+     EGLConfig eglConfig;
+     CreateConfig(*egl, &eglConfig, /* bpp */ 24, /* depth buffer? */ false,
+-                 aUseGles);
++                 aUseGles, /* aUseGles3 */ false);
+     auto gl = GLContextEGL::CreateGLContext(egl, {}, eglConfig, EGL_NO_SURFACE,
+                                             true, eglConfig, &ignored);
+     if (!gl) {
+diff --git a/gfx/gl/GLContextEGL.h b/gfx/gl/GLContextEGL.h
+index fcf3782f24727..fd869d3125c57 100644
+--- a/gfx/gl/GLContextEGL.h
++++ b/gfx/gl/GLContextEGL.h
+@@ -156,6 +156,7 @@ class GLContextEGL final : public GLContext {
+ 
+ bool CreateConfig(EglDisplay&, EGLConfig* aConfig, int32_t aDepth,
+                   bool aEnableDepthBuffer, bool aUseGles,
++                  bool aUseGles3,
+                   bool aAllowFallback = true);
+ 
+ }  // namespace gl
+diff --git a/gfx/gl/GLContextProviderEGL.cpp b/gfx/gl/GLContextProviderEGL.cpp
+index 252e027b63f86..04a06293b4d00 100644
+--- a/gfx/gl/GLContextProviderEGL.cpp
++++ b/gfx/gl/GLContextProviderEGL.cpp
+@@ -74,6 +74,11 @@
+ #include "nsThreadUtils.h"
+ #include "ScopedGLHelpers.h"
+ 
++#ifdef MOZ_WIDGET_QT
++#  include <QGuiApplication>
++#  include <qpa/qplatformnativeinterface.h>
++#endif
++
+ #if defined(MOZ_WIDGET_GTK)
+ #  include "mozilla/widget/GtkCompositorWidget.h"
+ #  if defined(MOZ_WAYLAND)
+@@ -93,6 +98,34 @@ namespace gl {
+ 
+ using namespace mozilla::widget;
+ 
++#ifdef MOZ_WIDGET_QT
++// Use Qt's EGLDisplay so that Gecko and the Qt platform plugin share the same
++// Wayland connection.
++static EGLDisplay GetAppDisplay() {
++  auto* const interface = QGuiApplication::platformNativeInterface();
++  if (!interface) {
++    return EGL_NO_DISPLAY;
++  }
++  return static_cast<EGLDisplay>(interface->nativeResourceForIntegration(
++      QByteArrayLiteral("egldisplay")));
++}
++#endif
++
++static std::shared_ptr<EglDisplay> CreateDisplayForApp(
++    GLLibraryEGL& lib, const bool forceAccel,
++    nsACString* const out_failureId) {
++#ifdef MOZ_WIDGET_QT
++  const auto display = GetAppDisplay();
++  if (display != EGL_NO_DISPLAY) {
++    return lib.CreateBorrowedDisplay(display, out_failureId);
++  }
++#endif
++  if (forceAccel) {
++    return lib.CreateDisplay(true, out_failureId);
++  }
++  return lib.DefaultDisplay(out_failureId);
++}
++
+ #if defined(MOZ_WAYLAND)
+ class SavedGLSurface {
+  public:
+@@ -118,7 +151,7 @@ void DeleteSavedGLSurface(EGLSurface surface) {
+ 
+ static bool CreateConfigScreen(EglDisplay&, EGLConfig* const aConfig,
+                                const bool aEnableDepthBuffer,
+-                               const bool aUseGles);
++                               const bool aUseGles, const bool aUseGles3);
+ 
+ // append three zeros at the end of attribs list to work around
+ // EGL implementation bugs that iterate until they find 0, instead of
+@@ -237,7 +270,7 @@ already_AddRefed<GLContext> GLContextEGLFactory::CreateImpl(
+     gfxCriticalNote << "Failed[3] to load EGL library: " << failureId.get();
+     return nullptr;
+   }
+-  const auto egl = lib->CreateDisplay(true, &failureId);
++  const auto egl = CreateDisplayForApp(*lib, true, &failureId);
+   if (!egl) {
+     gfxCriticalNote << "Failed[3] to create EGL library  display: "
+                     << failureId.get();
+@@ -245,25 +278,34 @@ already_AddRefed<GLContext> GLContextEGLFactory::CreateImpl(
+   }
+ 
+   bool doubleBuffered = true;
++  const bool useGles3 = aHardwareWebRender && aUseGles;
++#ifdef MOZ_WIDGET_QT
++  // Qt's Wayland EGL integration uses an alpha-capable window config even
++  // when the logical screen depth does not include alpha.
++  const bool useAlphaConfig = true;
++#else
++  const bool useAlphaConfig = kIsWayland || kIsX11;
++#endif
+ 
+   EGLConfig config;
+   if (aHardwareWebRender && egl->mLib->IsANGLE()) {
+     // Force enable alpha channel to make sure ANGLE use correct framebuffer
+     // formart
+     const int bpp = 32;
+-    if (!CreateConfig(*egl, &config, bpp, false, aUseGles)) {
++    if (!CreateConfig(*egl, &config, bpp, false, aUseGles, useGles3)) {
+       gfxCriticalNote << "Failed to create EGLConfig for WebRender ANGLE!";
+       return nullptr;
+     }
+-  } else if (kIsWayland || kIsX11) {
++  } else if (useAlphaConfig) {
+     const int bpp = 32;
+-    if (!CreateConfig(*egl, &config, bpp, false, aUseGles)) {
++    if (!CreateConfig(*egl, &config, bpp, false, aUseGles, useGles3)) {
+       gfxCriticalNote << "Failed to create EGLConfig for WebRender!";
+       return nullptr;
+     }
+   } else {
+     if (!CreateConfigScreen(*egl, &config,
+-                            /* aEnableDepthBuffer */ false, aUseGles)) {
++                            /* aEnableDepthBuffer */ false, aUseGles,
++                            useGles3)) {
+       gfxCriticalNote << "Failed to create EGLConfig!";
+       return nullptr;
+     }
+@@ -339,7 +381,12 @@ already_AddRefed<GLContext> GLContextEGLFactory::Create(
+ EGLSurface GLContextEGL::CreateEGLSurfaceForCompositorWidget(
+     widget::CompositorWidget* aCompositorWidget, const EGLConfig aConfig) {
+   nsCString discardFailureId;
+-  const auto egl = DefaultEglDisplay(&discardFailureId);
++  const auto lib = GLLibraryEGL::Get(&discardFailureId);
++  if (!lib) {
++    gfxCriticalNote << "Failed to load EGL library 6!";
++    return EGL_NO_SURFACE;
++  }
++  const auto egl = CreateDisplayForApp(*lib, false, &discardFailureId);
+   if (!egl) {
+     gfxCriticalNote << "Failed to load EGL library 6!";
+     return EGL_NO_SURFACE;
+@@ -882,7 +929,8 @@ static const EGLint kEGLConfigAttribsRGBA32[] = {
+     LOCAL_EGL_ALPHA_SIZE,   8};
+ 
+ bool CreateConfig(EglDisplay& aEgl, EGLConfig* aConfig, int32_t aDepth,
+-                  bool aEnableDepthBuffer, bool aUseGles, bool aAllowFallback) {
++                  bool aEnableDepthBuffer, bool aUseGles, bool aUseGles3,
++                  bool aAllowFallback) {
+   EGLConfig configs[64];
+   std::vector<EGLint> attribs;
+   EGLint ncfg = ArrayLength(configs);
+@@ -908,10 +956,11 @@ bool CreateConfig(EglDisplay& aEgl, EGLConfig* aConfig, int32_t aDepth,
+       return false;
+   }
+ 
+-  if (aUseGles) {
+-    attribs.push_back(LOCAL_EGL_RENDERABLE_TYPE);
+-    attribs.push_back(LOCAL_EGL_OPENGL_ES2_BIT);
+-  }
++  MOZ_ASSERT_IF(aUseGles3, aUseGles);
++  attribs.push_back(LOCAL_EGL_RENDERABLE_TYPE);
++  attribs.push_back(aUseGles ? (aUseGles3 ? LOCAL_EGL_OPENGL_ES3_BIT_KHR
++                                          : LOCAL_EGL_OPENGL_ES2_BIT)
++                             : LOCAL_EGL_OPENGL_BIT);
+   for (const auto& cur : kTerminationAttribs) {
+     attribs.push_back(cur);
+   }
+@@ -983,21 +1032,24 @@ bool CreateConfig(EglDisplay& aEgl, EGLConfig* aConfig, int32_t aDepth,
+ // have the value null.
+ static bool CreateConfigScreen(EglDisplay& egl, EGLConfig* const aConfig,
+                                const bool aEnableDepthBuffer,
+-                               const bool aUseGles) {
++                               const bool aUseGles, const bool aUseGles3) {
+   int32_t depth = gfxVars::ScreenDepth();
+-  if (CreateConfig(egl, aConfig, depth, aEnableDepthBuffer, aUseGles)) {
++  if (CreateConfig(egl, aConfig, depth, aEnableDepthBuffer, aUseGles,
++                   aUseGles3)) {
+     return true;
+   }
+ #ifdef MOZ_WIDGET_ANDROID
+   // Bug 736005
+   // Android doesn't always support 16 bit so also try 24 bit
+   if (depth == 16) {
+-    return CreateConfig(egl, aConfig, 24, aEnableDepthBuffer, aUseGles);
++    return CreateConfig(egl, aConfig, 24, aEnableDepthBuffer, aUseGles,
++                        aUseGles3);
+   }
+   // Bug 970096
+   // Some devices that have 24 bit screens only support 16 bit OpenGL?
+   if (depth == 24) {
+-    return CreateConfig(egl, aConfig, 16, aEnableDepthBuffer, aUseGles);
++    return CreateConfig(egl, aConfig, 16, aEnableDepthBuffer, aUseGles,
++                        aUseGles3);
+   }
+ #endif
+   return false;
+@@ -1122,7 +1174,8 @@ bool GLContextEGL::FindVisual(int* const out_visualId) {
+   EGLConfig config;
+   const int bpp = 32;
+   if (!CreateConfig(*egl, &config, bpp, /* aEnableDepthBuffer */ false,
+-                    /* aUseGles */ false, /* aAllowFallback */ false)) {
++                    /* aUseGles */ false, /* aUseGles3 */ false,
++                    /* aAllowFallback */ false)) {
+     // We are on a buggy driver. Do not return a visual so a fallback path can
+     // be used. See https://gitlab.freedesktop.org/mesa/mesa/-/issues/149
+     return false;
+@@ -1229,7 +1282,11 @@ RefPtr<GLContextEGL> GLContextEGL::CreateWithoutSurface(
+ /*static*/
+ already_AddRefed<GLContext> GLContextProviderEGL::CreateHeadless(
+     const GLContextCreateDesc& desc, nsACString* const out_failureId) {
+-  const auto display = DefaultEglDisplay(out_failureId);
++  const auto lib = GLLibraryEGL::Get(out_failureId);
++  if (!lib) {
++    return nullptr;
++  }
++  const auto display = CreateDisplayForApp(*lib, false, out_failureId);
+   if (!display) {
+     return nullptr;
+   }
+diff --git a/gfx/gl/GLLibraryEGL.cpp b/gfx/gl/GLLibraryEGL.cpp
+index 24926227c3ce8..158b13a017001 100644
+--- a/gfx/gl/GLLibraryEGL.cpp
++++ b/gfx/gl/GLLibraryEGL.cpp
+@@ -166,7 +166,8 @@ static std::shared_ptr<EglDisplay> GetAndInitDisplay(
+     const StaticMutexAutoLock& aProofOfLock) {
+   const auto display = egl.fGetDisplay(displayType);
+   if (!display) return nullptr;
+-  return EglDisplay::Create(egl, display, false, aProofOfLock);
++  return EglDisplay::Create(egl, display, false,
++                            EglDisplay::Ownership::Owned, aProofOfLock);
+ }
+ 
+ #ifdef MOZ_WAYLAND
+@@ -207,7 +208,8 @@ static std::shared_ptr<EglDisplay> GetAndInitDeviceDisplay(
+     return nullptr;
+   }
+ 
+-  return EglDisplay::Create(egl, display, true, aProofOfLock);
++  return EglDisplay::Create(egl, display, true,
++                            EglDisplay::Ownership::Owned, aProofOfLock);
+ }
+ 
+ static std::shared_ptr<EglDisplay> GetAndInitSoftwareDisplay(
+@@ -245,7 +247,8 @@ static std::shared_ptr<EglDisplay> GetAndInitSoftwareDisplay(
+     return nullptr;
+   }
+ 
+-  return EglDisplay::Create(egl, display, true, aProofOfLock);
++  return EglDisplay::Create(egl, display, true,
++                            EglDisplay::Ownership::Owned, aProofOfLock);
+ }
+ 
+ static std::shared_ptr<EglDisplay> GetAndInitSurfacelessDisplay(
+@@ -260,7 +263,8 @@ static std::shared_ptr<EglDisplay> GetAndInitSurfacelessDisplay(
+   if (display == EGL_NO_DISPLAY) {
+     return nullptr;
+   }
+-  return EglDisplay::Create(egl, display, true, aProofOfLock);
++  return EglDisplay::Create(egl, display, true,
++                            EglDisplay::Ownership::Owned, aProofOfLock);
+ }
+ #endif
+ 
+@@ -295,7 +299,8 @@ static std::shared_ptr<EglDisplay> GetAndInitWARPDisplay(
+     return nullptr;
+   }
+ 
+-  return EglDisplay::Create(egl, display, true, aProofOfLock);
++  return EglDisplay::Create(egl, display, true,
++                            EglDisplay::Ownership::Owned, aProofOfLock);
+ }
+ 
+ std::shared_ptr<EglDisplay> GLLibraryEGL::CreateDisplay(
+@@ -328,7 +333,8 @@ std::shared_ptr<EglDisplay> GLLibraryEGL::CreateDisplay(
+     return nullptr;
+   }
+ 
+-  const auto ret = EglDisplay::Create(*this, display, false, lock);
++  const auto ret = EglDisplay::Create(*this, display, false,
++                                      EglDisplay::Ownership::Owned, lock);
+ 
+   if (!ret) {
+     const EGLint err = fGetError();
+@@ -797,6 +803,7 @@ static void MarkExtensions(const char* rawExtString, bool shouldDumpExts,
+ // static
+ std::shared_ptr<EglDisplay> EglDisplay::Create(
+     GLLibraryEGL& lib, const EGLDisplay display, const bool isWarp,
++    const Ownership ownership,
+     const StaticMutexAutoLock& aProofOfLock) {
+   // Retrieve the EglDisplay if it already exists
+   {
+@@ -804,20 +811,28 @@ std::shared_ptr<EglDisplay> EglDisplay::Create(
+     if (itr != lib.mActiveDisplays.end()) {
+       const auto ret = itr->second.lock();
+       if (ret) {
++        if (ret->mOwnership != ownership) {
++          MOZ_ASSERT(false, "Cannot change EGLDisplay ownership");
++          return nullptr;
++        }
+         return ret;
+       }
+     }
+   }
+ 
+-  if (!lib.fInitialize(display, nullptr, nullptr)) {
++  if (ownership == Ownership::Owned) {
++    if (!lib.fInitialize(display, nullptr, nullptr)) {
++      return nullptr;
++    }
++  } else if (!lib.fQueryString(display, LOCAL_EGL_VERSION)) {
+     return nullptr;
+   }
+ 
+   static std::once_flag sMesaLeakFlag;
+   std::call_once(sMesaLeakFlag, MesaMemoryLeakWorkaround);
+ 
+-  const auto ret =
+-      std::make_shared<EglDisplay>(PrivateUseOnly{}, lib, display, isWarp);
++  const auto ret = std::make_shared<EglDisplay>(PrivateUseOnly{}, lib, display,
++                                                isWarp, ownership);
+   // Insert if there is no existing display entry, or assign if there is an
+   // expired weak_ptr that failed to lock above and was awaiting removal.
+   lib.mActiveDisplays.insert_or_assign(display, ret);
+@@ -825,8 +840,12 @@ std::shared_ptr<EglDisplay> EglDisplay::Create(
+ }
+ 
+ EglDisplay::EglDisplay(const PrivateUseOnly&, GLLibraryEGL& lib,
+-                       const EGLDisplay disp, const bool isWarp)
+-    : mLib(&lib), mDisplay(disp), mIsWARP(isWarp) {
++                       const EGLDisplay disp, const bool isWarp,
++                       const Ownership ownership)
++    : mLib(&lib),
++      mDisplay(disp),
++      mIsWARP(isWarp),
++      mOwnership(ownership) {
+   const bool shouldDumpExts = GLContext::ShouldDumpExts();
+ 
+   auto rawExtString =
+@@ -877,7 +896,9 @@ EglDisplay::~EglDisplay() {
+   if (itr != mLib->mActiveDisplays.end() && !itr->second.expired()) {
+     return;
+   }
+-  fTerminate();
++  if (mOwnership == Ownership::Owned) {
++    fTerminate();
++  }
+   mLib->mActiveDisplays.erase(mDisplay);
+ }
+ 
+@@ -900,7 +921,7 @@ std::shared_ptr<EglDisplay> GLLibraryEGL::CreateDisplay(
+   return CreateDisplayLocked(forceAccel, out_failureId, lock);
+ }
+ 
+-std::shared_ptr<EglDisplay> GLLibraryEGL::CreateDisplay(
++std::shared_ptr<EglDisplay> GLLibraryEGL::CreateBorrowedDisplay(
+     const EGLDisplay display, nsACString* const out_failureId) {
+   if (!display) {
+     if (out_failureId && out_failureId->IsEmpty()) {
+@@ -910,7 +931,8 @@ std::shared_ptr<EglDisplay> GLLibraryEGL::CreateDisplay(
+   }
+ 
+   StaticMutexAutoLock lock(sMutex);
+-  auto ret = EglDisplay::Create(*this, display, false, lock);
++  auto ret = EglDisplay::Create(*this, display, false,
++                                EglDisplay::Ownership::Borrowed, lock);
+   if (!ret && out_failureId && out_failureId->IsEmpty()) {
+     *out_failureId = "FEATURE_FAILURE_EGL_DISPLAY"_ns;
+   }
+diff --git a/gfx/gl/GLLibraryEGL.h b/gfx/gl/GLLibraryEGL.h
+index 5cf95aae9406a..79273ea57f77c 100644
+--- a/gfx/gl/GLLibraryEGL.h
++++ b/gfx/gl/GLLibraryEGL.h
+@@ -159,8 +159,8 @@ class GLLibraryEGL final {
+ 
+   std::shared_ptr<EglDisplay> CreateDisplay(bool forceAccel,
+                                             nsACString* const out_failureId);
+-  std::shared_ptr<EglDisplay> CreateDisplay(EGLDisplay display,
+-                                            nsACString* const out_failureId);
++  std::shared_ptr<EglDisplay> CreateBorrowedDisplay(
++      EGLDisplay display, nsACString* const out_failureId);
+   std::shared_ptr<EglDisplay> CreateDisplay(ID3D11Device*);
+   std::shared_ptr<EglDisplay> DefaultDisplay(nsACString* const out_failureId);
+ 
+@@ -698,9 +698,12 @@ class GLLibraryEGL final {
+ 
+ class EglDisplay final {
+  public:
++  enum class Ownership { Borrowed, Owned };
++
+   const RefPtr<GLLibraryEGL> mLib;
+   const EGLDisplay mDisplay;
+   const bool mIsWARP;
++  const Ownership mOwnership;
+ 
+  private:
+   std::bitset<UnderlyingValue(EGLExtension::Max)> mAvailableExtensions;
+@@ -709,11 +712,12 @@ class EglDisplay final {
+ 
+  public:
+   static std::shared_ptr<EglDisplay> Create(
+-      GLLibraryEGL&, EGLDisplay, bool isWarp,
++      GLLibraryEGL&, EGLDisplay, bool isWarp, Ownership,
+       const StaticMutexAutoLock& aProofOfLock);
+ 
+   // Only `public` for make_shared.
+-  EglDisplay(const PrivateUseOnly&, GLLibraryEGL&, EGLDisplay, bool isWarp);
++  EglDisplay(const PrivateUseOnly&, GLLibraryEGL&, EGLDisplay, bool isWarp,
++             Ownership);
+ 
+  public:
+   ~EglDisplay();
+diff --git a/gfx/gl/SharedSurfaceEGL.cpp b/gfx/gl/SharedSurfaceEGL.cpp
+index 09659ba519c12..85a45869b8dbf 100644
+--- a/gfx/gl/SharedSurfaceEGL.cpp
++++ b/gfx/gl/SharedSurfaceEGL.cpp
+@@ -27,7 +27,8 @@ static bool HasEglImageExtensions(const GLContextEGL& gl) {
+   const auto& egl = *(gl.mEgl);
+   return egl.HasKHRImageBase() &&
+          egl.IsExtensionSupported(EGLExtension::KHR_gl_texture_2D_image) &&
+-         (gl.IsExtensionSupported(GLContext::OES_EGL_image_external) ||
++         (!gl.IsGLES() ||
++          gl.IsExtensionSupported(GLContext::OES_EGL_image_external) ||
+           gl.IsExtensionSupported(GLContext::OES_EGL_image));
+ }
+ 
+diff --git a/gfx/gl/moz.build b/gfx/gl/moz.build
+index bf5b0d5fdd969..81af6ee302929 100644
+--- a/gfx/gl/moz.build
++++ b/gfx/gl/moz.build
+@@ -159,6 +159,9 @@ if CONFIG["MOZ_WIDGET_TOOLKIT"] == "gtk":
+     CXXFLAGS += CONFIG["MOZ_GTK3_CFLAGS"]
+     CFLAGS += CONFIG["MOZ_GTK3_CFLAGS"]
+ 
++if CONFIG["MOZ_WIDGET_TOOLKIT"] == "qt":
++    CXXFLAGS += CONFIG["MOZ_QT_CFLAGS"]
++
+ CXXFLAGS += ["-Werror=switch"]
+ 
+ if CONFIG["MOZ_WAYLAND"]:

--- a/rpm/0086-Support-software-WebRender-on-EmbedLite.patch
+++ b/rpm/0086-Support-software-WebRender-on-EmbedLite.patch
@@ -1,0 +1,205 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Branson <andrew.branson@jolla.com>
+Date: Thu, 23 Jul 2026 12:23:49 +0200
+Subject: [sailfishos][webrender] Support software rendering on EmbedLite
+
+Use the Qt EGL display to detect mainline drivers without a GLES 3
+configuration and select software WebRender before hardware context
+creation is attempted.
+
+Let EmbedLite use the shared OGL compositor context for software
+WebRender presentation while retaining the widget-derived surface size.
+This keeps GLES 2 presentation accelerated without requiring hardware
+WebRender support.
+---
+ gfx/gl/GLContextProvider.h                    |  4 +++
+ gfx/gl/GLContextProviderEGL.cpp               | 33 +++++++++++++++++++
+ gfx/thebes/gfxPlatform.cpp                    | 10 ++++++
+ .../RenderCompositorOGLSWGL.cpp               | 10 +++++-
+ .../RenderCompositorOGLSWGL.h                 |  1 +
+ gfx/webrender_bindings/RenderThread.cpp       |  5 +--
+ gfx/webrender_bindings/RendererOGL.cpp        |  4 ++-
+ widget/nsBaseWidget.cpp                       |  2 ++
+ 8 files changed, 65 insertions(+), 4 deletions(-)
+
+diff --git a/gfx/gl/GLContextProvider.h b/gfx/gl/GLContextProvider.h
+index 67da1bc67ca03..d604da23fd4d9 100644
+--- a/gfx/gl/GLContextProvider.h
++++ b/gfx/gl/GLContextProvider.h
+@@ -22,6 +22,10 @@ class CompositorWidget;
+ }
+ namespace gl {
+ 
++#ifdef MOZ_WIDGET_QT
++bool QtEGLDisplayRequiresSoftwareWebRender();
++#endif
++
+ #define IN_GL_CONTEXT_PROVIDER_H
+ 
+ // Null is always there
+diff --git a/gfx/gl/GLContextProviderEGL.cpp b/gfx/gl/GLContextProviderEGL.cpp
+index 04a06293b4d00..5e1ba387226b8 100644
+--- a/gfx/gl/GLContextProviderEGL.cpp
++++ b/gfx/gl/GLContextProviderEGL.cpp
+@@ -1025,6 +1025,39 @@ bool CreateConfig(EglDisplay& aEgl, EGLConfig* aConfig, int32_t aDepth,
+   return false;
+ }
+ 
++#ifdef MOZ_WIDGET_QT
++bool QtEGLDisplayRequiresSoftwareWebRender() {
++  const EGLDisplay display = GetAppDisplay();
++  if (display == EGL_NO_DISPLAY) {
++    return false;
++  }
++
++  nsCString failureId;
++  const auto lib = GLLibraryEGL::Get(&failureId);
++  if (!lib) {
++    return false;
++  }
++  const auto egl = lib->CreateBorrowedDisplay(display, &failureId);
++  if (!egl) {
++    return false;
++  }
++
++  const auto* extensions = reinterpret_cast<const GLubyte*>(
++      egl->mLib->fQueryString(egl->mDisplay, LOCAL_EGL_EXTENSIONS));
++  if (GLContext::ListHasExtension(extensions,
++                                  "EGL_HYBRIS_native_buffer") ||
++      GLContext::ListHasExtension(extensions,
++                                  "EGL_HYBRIS_native_buffer2")) {
++    return false;
++  }
++
++  EGLConfig config;
++  return !CreateConfig(*egl, &config, /* aDepth */ 32,
++                       /* aEnableDepthBuffer */ false,
++                       /* aUseGles */ true, /* aUseGles3 */ true);
++}
++#endif
++
+ // Return true if a suitable EGLConfig was found and pass it out
+ // through aConfig.  Return false otherwise.
+ //
+diff --git a/gfx/thebes/gfxPlatform.cpp b/gfx/thebes/gfxPlatform.cpp
+index a7a63d728aced..de99e9016c768 100644
+--- a/gfx/thebes/gfxPlatform.cpp
++++ b/gfx/thebes/gfxPlatform.cpp
+@@ -2648,6 +2648,16 @@ void gfxPlatform::InitWebRenderConfig() {
+   manager.Init();
+   manager.ConfigureWebRender();
+ 
++#ifdef MOZ_WIDGET_QT
++  if (gfxConfig::IsEnabled(Feature::WEBRENDER) &&
++      gl::QtEGLDisplayRequiresSoftwareWebRender()) {
++    gfxConfig::GetFeature(Feature::WEBRENDER)
++        .ForceDisable(FeatureStatus::Unavailable,
++                      "Qt EGL display has no WebRender-compatible config",
++                      "FEATURE_FAILURE_WEBRENDER_QT_EGL_NO_GLES3"_ns);
++  }
++#endif
++
+   bool hasHardware = gfxConfig::IsEnabled(Feature::WEBRENDER);
+ 
+ #ifdef MOZ_WIDGET_GTK
+diff --git a/gfx/webrender_bindings/RenderCompositorOGLSWGL.cpp b/gfx/webrender_bindings/RenderCompositorOGLSWGL.cpp
+index fac9722bbea4a..00ae03ff8e7a7 100644
+--- a/gfx/webrender_bindings/RenderCompositorOGLSWGL.cpp
++++ b/gfx/webrender_bindings/RenderCompositorOGLSWGL.cpp
+@@ -48,7 +48,7 @@ UniquePtr<RenderCompositor> RenderCompositorOGLSWGL::Create(
+   }
+ 
+   RefPtr<Compositor> compositor;
+-#ifdef MOZ_WIDGET_ANDROID
++#if defined(MOZ_WIDGET_ANDROID) || defined(MOZ_EMBEDLITE)
+   RefPtr<gl::GLContext> context =
+       RenderThread::Get()->SingletonGLForCompositorOGL();
+   if (!context) {
+@@ -63,9 +63,13 @@ UniquePtr<RenderCompositor> RenderCompositorOGLSWGL::Create(
+ 
+   nsCString log;
+   RefPtr<CompositorOGL> compositorOGL;
++#  ifdef MOZ_WIDGET_ANDROID
+   compositorOGL = new CompositorOGL(aWidget, /* aSurfaceWidth */ -1,
+                                     /* aSurfaceHeight */ -1,
+                                     /* aUseExternalSurfaceSize */ true);
++#  else
++  compositorOGL = new CompositorOGL(aWidget);
++#  endif
+   if (!compositorOGL->Initialize(context, programs, &log)) {
+     gfxCriticalNote << "Failed to initialize CompositorOGL for SWGL: "
+                     << log.get();
+@@ -116,6 +120,10 @@ gl::GLContext* RenderCompositorOGLSWGL::GetGLContext() {
+   return mCompositor->AsCompositorOGL()->gl();
+ }
+ 
++gl::GLContext* RenderCompositorOGLSWGL::gl() const {
++  return mCompositor->AsCompositorOGL()->gl();
++}
++
+ bool RenderCompositorOGLSWGL::MakeCurrent() {
+   GetGLContext()->MakeCurrent();
+ #ifdef MOZ_WIDGET_ANDROID
+diff --git a/gfx/webrender_bindings/RenderCompositorOGLSWGL.h b/gfx/webrender_bindings/RenderCompositorOGLSWGL.h
+index 7752574311bf0..4bfa25a45a58c 100644
+--- a/gfx/webrender_bindings/RenderCompositorOGLSWGL.h
++++ b/gfx/webrender_bindings/RenderCompositorOGLSWGL.h
+@@ -29,6 +29,7 @@ class RenderCompositorOGLSWGL : public RenderCompositorLayersSWGL {
+   virtual ~RenderCompositorOGLSWGL();
+ 
+   gl::GLContext* GetGLContext();
++  gl::GLContext* gl() const override;
+ 
+   bool MakeCurrent() override;
+ 
+diff --git a/gfx/webrender_bindings/RenderThread.cpp b/gfx/webrender_bindings/RenderThread.cpp
+index a8b68aef94870..ed4c5e2ff236f 100644
+--- a/gfx/webrender_bindings/RenderThread.cpp
++++ b/gfx/webrender_bindings/RenderThread.cpp
+@@ -1535,7 +1535,8 @@ static already_AddRefed<gl::GLContext> CreateGLContextANGLE(
+ }
+ #endif
+ 
+-#if defined(MOZ_WIDGET_ANDROID) || defined(MOZ_WAYLAND) || defined(MOZ_X11)
++#if defined(MOZ_WIDGET_ANDROID) || defined(MOZ_WAYLAND) || \
++    defined(MOZ_X11) || defined(MOZ_EMBEDLITE)
+ static already_AddRefed<gl::GLContext> CreateGLContextEGL() {
+   // Create GLContext with dummy EGLSurface.
+   bool forHardwareWebRender = true;
+@@ -1572,7 +1573,7 @@ static already_AddRefed<gl::GLContext> CreateGLContext(nsACString& aError) {
+   if (gfx::gfxVars::UseWebRenderANGLE()) {
+     gl = CreateGLContextANGLE(aError);
+   }
+-#elif defined(MOZ_WIDGET_ANDROID)
++#elif defined(MOZ_WIDGET_ANDROID) || defined(MOZ_EMBEDLITE)
+   gl = CreateGLContextEGL();
+ #elif defined(MOZ_WAYLAND) || defined(MOZ_X11)
+   if (gfx::gfxVars::UseEGL()) {
+diff --git a/gfx/webrender_bindings/RendererOGL.cpp b/gfx/webrender_bindings/RendererOGL.cpp
+index 3eac1b7da8f51..81277eab5722d 100644
+--- a/gfx/webrender_bindings/RendererOGL.cpp
++++ b/gfx/webrender_bindings/RendererOGL.cpp
+@@ -300,7 +300,9 @@ layers::SyncObjectHost* RendererOGL::GetSyncObject() const {
+   return mCompositor->GetSyncObject();
+ }
+ 
+-gl::GLContext* RendererOGL::gl() const { return mCompositor->gl(); }
++gl::GLContext* RendererOGL::gl() const {
++  return mCompositor->swgl() ? nullptr : mCompositor->gl();
++}
+ 
+ void* RendererOGL::swgl() const { return mCompositor->swgl(); }
+ 
+diff --git a/widget/nsBaseWidget.cpp b/widget/nsBaseWidget.cpp
+index ef102467f68da..70729e163ba6a 100644
+--- a/widget/nsBaseWidget.cpp
++++ b/widget/nsBaseWidget.cpp
+@@ -1392,6 +1392,8 @@ already_AddRefed<WebRenderLayerManager> nsBaseWidget::CreateCompositorSession(
+     MOZ_ASSERT(supportsAcceleration);
+     options.SetAllowSoftwareWebRenderOGL(
+         StaticPrefs::gfx_webrender_software_opengl_AtStartup());
++#elif defined(MOZ_EMBEDLITE)
++    options.SetAllowSoftwareWebRenderOGL(supportsAcceleration);
+ #elif defined(MOZ_WIDGET_GTK)
+     if (supportsAcceleration) {
+       options.SetAllowSoftwareWebRenderOGL(

--- a/rpm/0087-Add-safe-Qt-display-fallback-for-hybris.patch
+++ b/rpm/0087-Add-safe-Qt-display-fallback-for-hybris.patch
@@ -1,0 +1,737 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Branson <andrew.branson@jolla.com>
+Date: Thu, 23 Jul 2026 16:19:48 +0200
+Subject: [sailfishos][egl] Add safe Qt display fallback for hybris
+
+On hybris, probe a GLES 3 context on Qt's borrowed EGLDisplay before using it
+for hardware WebRender. Require context creation, MakeCurrent(), GLES, and a
+version of at least 3.0.
+
+When no wrapper is active, discard a rejected borrowed wrapper before
+creating Gecko's legacy owned display. If the probe context cannot be unbound,
+retain it and return failure so active-display ownership entries cannot
+collide. An active borrowed wrapper cannot be discarded; rejected probes
+return failure instead of switching ownership.
+
+Identify hybris through EGL_HYBRIS_native_buffer extensions. Keep Mesa bound
+to Qt's borrowed display for direct EGLImage sharing, and restrict desktop GL
+EGLImage sharing to borrowed Qt displays. Reuse SingletonGL for EmbedLite's
+borrowed GLES 3 compositor path so WebRender shader objects stay in their
+creating context.
+
+Report focused failure IDs for borrowed display, config, surface, and context
+creation failures.
+---
+ gfx/gl/GLContextEGL.h           |   8 +-
+ gfx/gl/GLContextProviderEGL.cpp | 466 ++++++++++++++++++++++++--------
+ gfx/gl/GLLibraryEGL.cpp         |  10 +
+ gfx/gl/GLLibraryEGL.h           |   1 +
+ gfx/gl/SharedSurfaceEGL.cpp     |   8 +-
+ 5 files changed, 379 insertions(+), 114 deletions(-)
+
+diff --git a/gfx/gl/GLContextEGL.h b/gfx/gl/GLContextEGL.h
+index fd869d3125c57..45a2b829f15cf 100644
+--- a/gfx/gl/GLContextEGL.h
++++ b/gfx/gl/GLContextEGL.h
+@@ -103,7 +103,7 @@ class GLContextEGL final : public GLContext {
+ 
+   static RefPtr<GLContextEGL> CreateWithoutSurface(
+       std::shared_ptr<EglDisplay>, const GLContextCreateDesc&,
+-      nsACString* const out_FailureId);
++      nsACString* const out_failureId);
+   static RefPtr<GLContextEGL> CreateEGLSurfacelessContext(
+       const std::shared_ptr<EglDisplay> display,
+       const GLContextCreateDesc& desc, nsACString* const out_failureId);
+@@ -119,6 +119,10 @@ class GLContextEGL final : public GLContext {
+   friend class GLContextProviderEGL;
+   friend class GLContextEGLFactory;
+ 
++  static RefPtr<GLContextEGL> CreateWithoutSurfaceForApi(
++      std::shared_ptr<EglDisplay>, const GLContextCreateDesc&, bool useGles,
++      nsACString* const out_failureId);
++
+   virtual void OnMarkDestroyed() override;
+ 
+  public:
+@@ -156,7 +160,7 @@ class GLContextEGL final : public GLContext {
+ 
+ bool CreateConfig(EglDisplay&, EGLConfig* aConfig, int32_t aDepth,
+                   bool aEnableDepthBuffer, bool aUseGles,
+-                  bool aUseGles3,
++                  bool aUseGles3 = false,
+                   bool aAllowFallback = true);
+ 
+ }  // namespace gl
+diff --git a/gfx/gl/GLContextProviderEGL.cpp b/gfx/gl/GLContextProviderEGL.cpp
+index 5e1ba387226b8..6038c439bb25c 100644
+--- a/gfx/gl/GLContextProviderEGL.cpp
++++ b/gfx/gl/GLContextProviderEGL.cpp
+@@ -109,6 +109,15 @@ static EGLDisplay GetAppDisplay() {
+   return static_cast<EGLDisplay>(interface->nativeResourceForIntegration(
+       QByteArrayLiteral("egldisplay")));
+ }
++
++static bool IsHybrisDisplay(GLLibraryEGL& lib, const EGLDisplay display) {
++  const auto* const extensions = reinterpret_cast<const GLubyte*>(
++      lib.fQueryString(display, LOCAL_EGL_EXTENSIONS));
++  return GLContext::ListHasExtension(extensions,
++                                     "EGL_HYBRIS_native_buffer") ||
++         GLContext::ListHasExtension(extensions,
++                                     "EGL_HYBRIS_native_buffer2");
++}
+ #endif
+ 
+ static std::shared_ptr<EglDisplay> CreateDisplayForApp(
+@@ -117,7 +126,18 @@ static std::shared_ptr<EglDisplay> CreateDisplayForApp(
+ #ifdef MOZ_WIDGET_QT
+   const auto display = GetAppDisplay();
+   if (display != EGL_NO_DISPLAY) {
+-    return lib.CreateBorrowedDisplay(display, out_failureId);
++    const bool isHybris = IsHybrisDisplay(lib, display);
++    if (const auto active = lib.GetActiveDisplay(display)) {
++      if (!isHybris &&
++          active->mOwnership != EglDisplay::Ownership::Borrowed) {
++        *out_failureId = "FEATURE_FAILURE_EGL_BORROWED_DISPLAY"_ns;
++        return nullptr;
++      }
++      return active;
++    }
++    if (!isHybris) {
++      return lib.CreateBorrowedDisplay(display, out_failureId);
++    }
+   }
+ #endif
+   if (forceAccel) {
+@@ -253,9 +273,10 @@ class GLContextEGLFactory {
+  public:
+   static already_AddRefed<GLContext> Create(EGLNativeWindowType aWindow,
+                                             bool aHardwareWebRender);
+-  static already_AddRefed<GLContext> CreateImpl(EGLNativeWindowType aWindow,
+-                                                bool aHardwareWebRender,
+-                                                bool aUseGles);
++  static already_AddRefed<GLContext> CreateImpl(
++      const std::shared_ptr<EglDisplay>& aEgl,
++      EGLNativeWindowType aWindow, bool aHardwareWebRender, bool aUseGles,
++      nsACString* aFailureId);
+ 
+  private:
+   GLContextEGLFactory() = default;
+@@ -263,47 +284,44 @@ class GLContextEGLFactory {
+ };
+ 
+ already_AddRefed<GLContext> GLContextEGLFactory::CreateImpl(
+-    EGLNativeWindowType aWindow, bool aHardwareWebRender, bool aUseGles) {
+-  nsCString failureId;
+-  const auto lib = GLLibraryEGL::Get(&failureId);
+-  if (!lib) {
+-    gfxCriticalNote << "Failed[3] to load EGL library: " << failureId.get();
+-    return nullptr;
+-  }
+-  const auto egl = CreateDisplayForApp(*lib, true, &failureId);
+-  if (!egl) {
+-    gfxCriticalNote << "Failed[3] to create EGL library  display: "
+-                    << failureId.get();
+-    return nullptr;
+-  }
+-
++    const std::shared_ptr<EglDisplay>& aEgl,
++    EGLNativeWindowType aWindow, bool aHardwareWebRender, bool aUseGles,
++    nsACString* const aFailureId) {
+   bool doubleBuffered = true;
+   const bool useGles3 = aHardwareWebRender && aUseGles;
+ #ifdef MOZ_WIDGET_QT
+   // Qt's Wayland EGL integration uses an alpha-capable window config even
+-  // when the logical screen depth does not include alpha.
+-  const bool useAlphaConfig = true;
++  // when the logical screen depth does not include alpha. Gecko-owned displays
++  // retain the legacy config selection used by hybris.
++  const bool useAlphaConfig =
++      aEgl->mOwnership == EglDisplay::Ownership::Borrowed;
+ #else
+   const bool useAlphaConfig = kIsWayland || kIsX11;
+ #endif
+ 
+   EGLConfig config;
+-  if (aHardwareWebRender && egl->mLib->IsANGLE()) {
++  if (aHardwareWebRender && aEgl->mLib->IsANGLE()) {
+     // Force enable alpha channel to make sure ANGLE use correct framebuffer
+     // formart
+     const int bpp = 32;
+-    if (!CreateConfig(*egl, &config, bpp, false, aUseGles, useGles3)) {
++    if (!CreateConfig(*aEgl, &config, bpp, false, aUseGles, useGles3)) {
++      if (aEgl->mOwnership == EglDisplay::Ownership::Borrowed) {
++        *aFailureId = "FEATURE_FAILURE_EGL_BORROWED_CONFIG"_ns;
++      }
+       gfxCriticalNote << "Failed to create EGLConfig for WebRender ANGLE!";
+       return nullptr;
+     }
+   } else if (useAlphaConfig) {
+     const int bpp = 32;
+-    if (!CreateConfig(*egl, &config, bpp, false, aUseGles, useGles3)) {
++    if (!CreateConfig(*aEgl, &config, bpp, false, aUseGles, useGles3)) {
++      if (aEgl->mOwnership == EglDisplay::Ownership::Borrowed) {
++        *aFailureId = "FEATURE_FAILURE_EGL_BORROWED_CONFIG"_ns;
++      }
+       gfxCriticalNote << "Failed to create EGLConfig for WebRender!";
+       return nullptr;
+     }
+   } else {
+-    if (!CreateConfigScreen(*egl, &config,
++    if (!CreateConfigScreen(*aEgl, &config,
+                             /* aEnableDepthBuffer */ false, aUseGles,
+                             useGles3)) {
+       gfxCriticalNote << "Failed to create EGLConfig!";
+@@ -313,8 +331,12 @@ already_AddRefed<GLContext> GLContextEGLFactory::CreateImpl(
+ 
+   EGLSurface surface = EGL_NO_SURFACE;
+   if (aWindow) {
+-    surface = mozilla::gl::CreateSurfaceFromNativeWindow(*egl, aWindow, config);
++    surface =
++        mozilla::gl::CreateSurfaceFromNativeWindow(*aEgl, aWindow, config);
+     if (!surface) {
++      if (aEgl->mOwnership == EglDisplay::Ownership::Borrowed) {
++        *aFailureId = "FEATURE_FAILURE_EGL_BORROWED_SURFACE"_ns;
++      }
+       return nullptr;
+     }
+   }
+@@ -333,33 +355,48 @@ already_AddRefed<GLContext> GLContextEGLFactory::CreateImpl(
+ 
+   const auto desc = GLContextDesc{{flags}, false};
+   RefPtr<GLContextEGL> gl = GLContextEGL::CreateGLContext(
+-      egl, desc, config, surface, aUseGles, config, &failureId);
++      aEgl, desc, config, surface, aUseGles, config, aFailureId);
+   if (!gl) {
+-    const auto err = egl->mLib->fGetError();
++    if (aEgl->mOwnership == EglDisplay::Ownership::Borrowed) {
++      *aFailureId = "FEATURE_FAILURE_EGL_BORROWED_CONTEXT"_ns;
++    }
++    const auto err = aEgl->mLib->fGetError();
+     gfxCriticalNote << "Failed to create EGLContext!: " << gfx::hexa(err);
+-    mozilla::gl::DestroySurface(*egl, surface);
++    mozilla::gl::DestroySurface(*aEgl, surface);
+     return nullptr;
+   }
+ 
+-  gl->MakeCurrent();
++  if (!gl->MakeCurrent()) {
++    if (aEgl->mOwnership == EglDisplay::Ownership::Borrowed) {
++      *aFailureId = "FEATURE_FAILURE_EGL_BORROWED_CONTEXT"_ns;
++    }
++    return nullptr;
++  }
+   gl->SetIsDoubleBuffered(doubleBuffered);
+ 
+ #ifdef MOZ_WIDGET_GTK
+   if (surface) {
+     const int interval = gfxVars::SwapIntervalEGL() ? 1 : 0;
+-    egl->fSwapInterval(interval);
++    aEgl->fSwapInterval(interval);
+   }
+ #endif
+-  if (aHardwareWebRender && egl->mLib->IsANGLE()) {
++  if (aHardwareWebRender && aEgl->mLib->IsANGLE()) {
+     MOZ_ASSERT(doubleBuffered);
+     const int interval = gfxVars::SwapIntervalEGL() ? 1 : 0;
+-    egl->fSwapInterval(interval);
++    aEgl->fSwapInterval(interval);
+   }
+   return gl.forget();
+ }
+ 
+ already_AddRefed<GLContext> GLContextEGLFactory::Create(
+     EGLNativeWindowType aWindow, bool aHardwareWebRender) {
++  nsCString failureId;
++  const auto lib = GLLibraryEGL::Get(&failureId);
++  if (!lib) {
++    gfxCriticalNote << "Failed[3] to load EGL library: " << failureId.get();
++    return nullptr;
++  }
++
+   bool preferGles;
+ #if defined(MOZ_WIDGET_ANDROID)
+   preferGles = true;
+@@ -367,14 +404,116 @@ already_AddRefed<GLContext> GLContextEGLFactory::Create(
+   preferGles = StaticPrefs::gfx_egl_prefer_gles_enabled_AtStartup();
+ #endif  // defined(MOZ_WIDGET_ANDROID)
+ 
+-  RefPtr<GLContext> glContext =
+-      CreateImpl(aWindow, aHardwareWebRender, preferGles);
++  const auto createForDisplay =
++      [&](const std::shared_ptr<EglDisplay>& egl) -> RefPtr<GLContext> {
++    RefPtr<GLContext> glContext =
++        CreateImpl(egl, aWindow, aHardwareWebRender, preferGles, &failureId);
+ #if !defined(MOZ_WIDGET_ANDROID)
+-  if (!glContext) {
+-    glContext = CreateImpl(aWindow, aHardwareWebRender, !preferGles);
+-  }
++    if (!glContext) {
++      glContext = CreateImpl(egl, aWindow, aHardwareWebRender, !preferGles,
++                             &failureId);
++    }
+ #endif  // !defined(MOZ_WIDGET_ANDROID)
+-  return glContext.forget();
++    return glContext;
++  };
++
++#ifdef MOZ_WIDGET_QT
++  const EGLDisplay appDisplay = GetAppDisplay();
++  if (appDisplay != EGL_NO_DISPLAY) {
++    const bool isHybris = IsHybrisDisplay(*lib, appDisplay);
++    if (const auto active = lib->GetActiveDisplay(appDisplay)) {
++      if (!isHybris &&
++          active->mOwnership != EglDisplay::Ownership::Borrowed) {
++        failureId = "FEATURE_FAILURE_EGL_BORROWED_DISPLAY"_ns;
++        return nullptr;
++      }
++      if (isHybris &&
++          active->mOwnership == EglDisplay::Ownership::Borrowed &&
++          !aWindow && aHardwareWebRender) {
++        CreateContextFlags flags = CreateContextFlags::PREFER_ES3;
++        if (StaticPrefs::gfx_webrender_prefer_robustness_AtStartup()) {
++          flags |= CreateContextFlags::PREFER_ROBUSTNESS;
++        }
++        RefPtr<GLContextEGL> gl =
++            GLContextEGL::CreateWithoutSurfaceForApi(
++                active, {flags}, /* useGles */ true, &failureId);
++        const bool madeCurrent = gl && gl->MakeCurrent();
++        if (madeCurrent && gl->IsGLES() && gl->Version() >= 300) {
++          return gl.forget();
++        }
++        if (gl) {
++          failureId = "FEATURE_FAILURE_EGL_BORROWED_CONTEXT"_ns;
++          if (madeCurrent &&
++              !active->fMakeCurrent(EGL_NO_SURFACE, EGL_NO_SURFACE,
++                                    EGL_NO_CONTEXT)) {
++            // Intentionally retain the context and borrowed wrapper so a
++            // later owned wrapper cannot collide with the still-current
++            // display.
++            (void)gl.forget().take();
++            return nullptr;
++          }
++        }
++        // An active borrowed wrapper is owned by another caller, so it cannot
++        // be discarded here without colliding with an owned wrapper.
++        return nullptr;
++      }
++      return createForDisplay(active).forget();
++    }
++
++    if (!isHybris) {
++      const auto borrowed =
++          lib->CreateBorrowedDisplay(appDisplay, &failureId);
++      if (!borrowed) {
++        return nullptr;
++      }
++      return createForDisplay(borrowed).forget();
++    }
++
++    if (!aWindow && aHardwareWebRender) {
++      auto borrowed = lib->CreateBorrowedDisplay(appDisplay, &failureId);
++      if (borrowed) {
++        CreateContextFlags flags = CreateContextFlags::PREFER_ES3;
++        if (StaticPrefs::gfx_webrender_prefer_robustness_AtStartup()) {
++          flags |= CreateContextFlags::PREFER_ROBUSTNESS;
++        }
++        RefPtr<GLContextEGL> gl =
++            GLContextEGL::CreateWithoutSurfaceForApi(
++                borrowed, {flags}, /* useGles */ true, &failureId);
++        const bool madeCurrent = gl && gl->MakeCurrent();
++        if (madeCurrent && gl->IsGLES() && gl->Version() >= 300) {
++          return gl.forget();
++        }
++        if (gl) {
++          failureId = "FEATURE_FAILURE_EGL_BORROWED_CONTEXT"_ns;
++          if (madeCurrent &&
++              !borrowed->fMakeCurrent(EGL_NO_SURFACE, EGL_NO_SURFACE,
++                                      EGL_NO_CONTEXT)) {
++            // Intentionally retain the context and borrowed wrapper so a
++            // later owned wrapper cannot collide with the still-current
++            // display.
++            (void)gl.forget().take();
++            return nullptr;
++          }
++        }
++        gl = nullptr;
++        borrowed.reset();
++      }
++      gfxCriticalNote
++          << "Qt borrowed EGL display cannot provide a GLES 3 WebRender "
++             "context; using Gecko's display: "
++          << failureId.get();
++    }
++  }
++#endif
++
++  failureId.Truncate();
++  const auto egl = lib->CreateDisplay(true, &failureId);
++  if (!egl) {
++    gfxCriticalNote << "Failed[3] to create EGL library display: "
++                    << failureId.get();
++    return nullptr;
++  }
++  return createForDisplay(egl).forget();
+ }
+ 
+ /* static */
+@@ -957,10 +1096,23 @@ bool CreateConfig(EglDisplay& aEgl, EGLConfig* aConfig, int32_t aDepth,
+   }
+ 
+   MOZ_ASSERT_IF(aUseGles3, aUseGles);
+-  attribs.push_back(LOCAL_EGL_RENDERABLE_TYPE);
+-  attribs.push_back(aUseGles ? (aUseGles3 ? LOCAL_EGL_OPENGL_ES3_BIT_KHR
+-                                          : LOCAL_EGL_OPENGL_ES2_BIT)
+-                             : LOCAL_EGL_OPENGL_BIT);
++#ifdef MOZ_WIDGET_QT
++  const bool useLegacyConfig =
++      aEgl.mOwnership == EglDisplay::Ownership::Owned;
++#else
++  const bool useLegacyConfig = false;
++#endif
++  if (useLegacyConfig) {
++    if (aUseGles) {
++      attribs.push_back(LOCAL_EGL_RENDERABLE_TYPE);
++      attribs.push_back(LOCAL_EGL_OPENGL_ES2_BIT);
++    }
++  } else {
++    attribs.push_back(LOCAL_EGL_RENDERABLE_TYPE);
++    attribs.push_back(aUseGles ? (aUseGles3 ? LOCAL_EGL_OPENGL_ES3_BIT_KHR
++                                            : LOCAL_EGL_OPENGL_ES2_BIT)
++                               : LOCAL_EGL_OPENGL_BIT);
++  }
+   for (const auto& cur : kTerminationAttribs) {
+     attribs.push_back(cur);
+   }
+@@ -1037,17 +1189,11 @@ bool QtEGLDisplayRequiresSoftwareWebRender() {
+   if (!lib) {
+     return false;
+   }
+-  const auto egl = lib->CreateBorrowedDisplay(display, &failureId);
+-  if (!egl) {
++  if (IsHybrisDisplay(*lib, display)) {
+     return false;
+   }
+-
+-  const auto* extensions = reinterpret_cast<const GLubyte*>(
+-      egl->mLib->fQueryString(egl->mDisplay, LOCAL_EGL_EXTENSIONS));
+-  if (GLContext::ListHasExtension(extensions,
+-                                  "EGL_HYBRIS_native_buffer") ||
+-      GLContext::ListHasExtension(extensions,
+-                                  "EGL_HYBRIS_native_buffer2")) {
++  const auto egl = lib->CreateBorrowedDisplay(display, &failureId);
++  if (!egl) {
+     return false;
+   }
+ 
+@@ -1221,92 +1367,112 @@ bool GLContextEGL::FindVisual(int* const out_visualId) {
+ #endif
+ 
+ /*static*/
+-RefPtr<GLContextEGL> GLContextEGL::CreateWithoutSurface(
++RefPtr<GLContextEGL> GLContextEGL::CreateWithoutSurfaceForApi(
+     const std::shared_ptr<EglDisplay> egl, const GLContextCreateDesc& desc,
+-    nsACString* const out_failureId) {
+-  const auto WithUseGles = [&](const bool useGles) -> RefPtr<GLContextEGL> {
++    const bool useGles, nsACString* const out_failureId) {
++  const bool isBorrowed =
++      egl->mOwnership == EglDisplay::Ownership::Borrowed;
+ #ifdef MOZ_WIDGET_GTK
+-    // First try creating a context with no config and no surface, this is what
+-    // we really want, and seems to be the only way to make selecting software
+-    // Mesa init properly when it's not the first device.
+-    if (egl->IsExtensionSupported(EGLExtension::KHR_no_config_context) &&
+-        egl->IsExtensionSupported(EGLExtension::KHR_surfaceless_context)) {
+-      // These extensions have been supported by mesa and nvidia drivers
+-      // since 2014 or earlier, this is the preferred code path
+-      auto fullDesc = GLContextDesc{desc};
+-      fullDesc.isOffscreen = true;
+-      RefPtr<GLContextEGL> gl = GLContextEGL::CreateGLContext(
+-          egl, fullDesc, EGL_NO_CONFIG, EGL_NO_SURFACE, useGles, EGL_NO_CONFIG,
+-          out_failureId);
+-      if (gl) {
+-        return gl;
+-      }
+-      NS_WARNING(
+-          "Failed to create GLContext with no config and no surface, will try "
+-          "ChooseConfig");
++  // First try creating a context with no config and no surface, this is what
++  // we really want, and seems to be the only way to make selecting software
++  // Mesa init properly when it's not the first device.
++  if (egl->IsExtensionSupported(EGLExtension::KHR_no_config_context) &&
++      egl->IsExtensionSupported(EGLExtension::KHR_surfaceless_context)) {
++    // These extensions have been supported by mesa and nvidia drivers
++    // since 2014 or earlier, this is the preferred code path
++    auto fullDesc = GLContextDesc{desc};
++    fullDesc.isOffscreen = true;
++    RefPtr<GLContextEGL> gl = GLContextEGL::CreateGLContext(
++        egl, fullDesc, EGL_NO_CONFIG, EGL_NO_SURFACE, useGles, EGL_NO_CONFIG,
++        out_failureId);
++    if (gl) {
++      return gl;
+     }
++    if (isBorrowed) {
++      *out_failureId = "FEATURE_FAILURE_EGL_BORROWED_CONTEXT"_ns;
++    }
++    NS_WARNING(
++        "Failed to create GLContext with no config and no surface, will try "
++        "ChooseConfig");
++  }
+ #endif
+ 
+-    const EGLConfig surfaceConfig = ChooseConfig(*egl, desc, useGles);
+-    if (surfaceConfig == EGL_NO_CONFIG) {
++  const EGLConfig surfaceConfig = ChooseConfig(*egl, desc, useGles);
++  if (surfaceConfig == EGL_NO_CONFIG) {
++    if (isBorrowed) {
++      *out_failureId = "FEATURE_FAILURE_EGL_BORROWED_CONFIG"_ns;
++    } else {
+       *out_failureId = "FEATURE_FAILURE_EGL_NO_CONFIG"_ns;
+-      NS_WARNING("Failed to find a compatible config.");
+-      return nullptr;
+     }
++    NS_WARNING("Failed to find a compatible config.");
++    return nullptr;
++  }
+ 
+-    if (GLContext::ShouldSpew()) {
+-      egl->DumpEGLConfig(surfaceConfig);
+-    }
+-    const EGLConfig contextConfig =
+-        egl->IsExtensionSupported(EGLExtension::KHR_no_config_context)
+-            ? nullptr
+-            : surfaceConfig;
++  if (GLContext::ShouldSpew()) {
++    egl->DumpEGLConfig(surfaceConfig);
++  }
++  const EGLConfig contextConfig =
++      egl->IsExtensionSupported(EGLExtension::KHR_no_config_context)
++          ? nullptr
++          : surfaceConfig;
+ 
+-    auto dummySize = mozilla::gfx::IntSize{16, 16};
+-    EGLSurface surface = nullptr;
++  auto dummySize = mozilla::gfx::IntSize{16, 16};
++  EGLSurface surface = nullptr;
+ #ifdef MOZ_WAYLAND
+-    if (GdkIsWaylandDisplay()) {
+-      surface = GLContextEGL::CreateWaylandBufferSurface(*egl, surfaceConfig,
+-                                                         dummySize);
+-    } else
++  if (GdkIsWaylandDisplay()) {
++    surface = GLContextEGL::CreateWaylandBufferSurface(*egl, surfaceConfig,
++                                                       dummySize);
++  } else
+ #endif
+-    {
+-      surface = GLContextEGL::CreatePBufferSurfaceTryingPowerOfTwo(
+-          *egl, surfaceConfig, LOCAL_EGL_NONE, dummySize);
+-    }
+-    if (!surface) {
++  {
++    surface = GLContextEGL::CreatePBufferSurfaceTryingPowerOfTwo(
++        *egl, surfaceConfig, LOCAL_EGL_NONE, dummySize);
++  }
++  if (!surface) {
++    if (isBorrowed) {
++      *out_failureId = "FEATURE_FAILURE_EGL_BORROWED_SURFACE"_ns;
++    } else {
+       *out_failureId = "FEATURE_FAILURE_EGL_POT"_ns;
+-      NS_WARNING("Failed to create PBuffer for context!");
+-      return nullptr;
+     }
++    NS_WARNING("Failed to create PBuffer for context!");
++    return nullptr;
++  }
+ 
+-    auto fullDesc = GLContextDesc{desc};
+-    fullDesc.isOffscreen = true;
+-    RefPtr<GLContextEGL> gl =
+-        GLContextEGL::CreateGLContext(egl, fullDesc, surfaceConfig, surface,
+-                                      useGles, contextConfig, out_failureId);
+-    if (!gl) {
+-      NS_WARNING("Failed to create GLContext from PBuffer");
+-      egl->fDestroySurface(surface);
++  auto fullDesc = GLContextDesc{desc};
++  fullDesc.isOffscreen = true;
++  RefPtr<GLContextEGL> gl =
++      GLContextEGL::CreateGLContext(egl, fullDesc, surfaceConfig, surface,
++                                    useGles, contextConfig, out_failureId);
++  if (!gl) {
++    if (isBorrowed) {
++      *out_failureId = "FEATURE_FAILURE_EGL_BORROWED_CONTEXT"_ns;
++    }
++    NS_WARNING("Failed to create GLContext from PBuffer");
++    egl->fDestroySurface(surface);
+ #if defined(MOZ_WAYLAND)
+-      DeleteSavedGLSurface(surface);
++    DeleteSavedGLSurface(surface);
+ #endif
+-      return nullptr;
+-    }
++    return nullptr;
++  }
+ 
+-    return gl;
+-  };
++  return gl;
++}
+ 
++/*static*/
++RefPtr<GLContextEGL> GLContextEGL::CreateWithoutSurface(
++    const std::shared_ptr<EglDisplay> egl, const GLContextCreateDesc& desc,
++    nsACString* const out_failureId) {
+   bool preferGles;
+ #if defined(MOZ_WIDGET_ANDROID)
+   preferGles = true;
+ #else
+   preferGles = StaticPrefs::gfx_egl_prefer_gles_enabled_AtStartup();
+ #endif  // defined(MOZ_WIDGET_ANDROID)
+-  RefPtr<GLContextEGL> gl = WithUseGles(preferGles);
++  RefPtr<GLContextEGL> gl =
++      CreateWithoutSurfaceForApi(egl, desc, preferGles, out_failureId);
+ #if !defined(MOZ_WIDGET_ANDROID)
+   if (!gl) {
+-    gl = WithUseGles(!preferGles);
++    gl = CreateWithoutSurfaceForApi(egl, desc, !preferGles, out_failureId);
+   }
+ #endif  // !defined(MOZ_WIDGET_ANDROID)
+   return gl;
+@@ -1319,6 +1485,84 @@ already_AddRefed<GLContext> GLContextProviderEGL::CreateHeadless(
+   if (!lib) {
+     return nullptr;
+   }
++
++#ifdef MOZ_WIDGET_QT
++  const EGLDisplay appDisplay = GetAppDisplay();
++  if (appDisplay != EGL_NO_DISPLAY) {
++    const bool isHybris = IsHybrisDisplay(*lib, appDisplay);
++    const bool requireGles3 =
++        bool(desc.flags & CreateContextFlags::PREFER_ES3);
++    auto display = lib->GetActiveDisplay(appDisplay);
++
++    if (display) {
++      if (!isHybris &&
++          display->mOwnership != EglDisplay::Ownership::Borrowed) {
++        *out_failureId = "FEATURE_FAILURE_EGL_BORROWED_DISPLAY"_ns;
++        return nullptr;
++      }
++      if (isHybris &&
++          display->mOwnership == EglDisplay::Ownership::Borrowed &&
++          requireGles3) {
++        // In the WebRender compositor flow, the active borrowed display
++        // already backs RenderThread's SingletonGL. WebRender creates its
++        // shared shaders on that context, so a second, unshared EGL context
++        // cannot consume them. Let the compositor reuse SingletonGL instead.
++        out_failureId->Truncate();
++        return nullptr;
++      }
++
++      auto gl =
++          GLContextEGL::CreateWithoutSurface(display, desc, out_failureId);
++      return gl.forget();
++    }
++
++    if (!isHybris) {
++      display = lib->CreateBorrowedDisplay(appDisplay, out_failureId);
++      if (!display) {
++        return nullptr;
++      }
++      auto gl =
++          GLContextEGL::CreateWithoutSurface(display, desc, out_failureId);
++      return gl.forget();
++    }
++
++    if (requireGles3) {
++      nsCString borrowedFailureId;
++      auto borrowed =
++          lib->CreateBorrowedDisplay(appDisplay, &borrowedFailureId);
++      if (borrowed) {
++        RefPtr<GLContextEGL> gl =
++            GLContextEGL::CreateWithoutSurfaceForApi(
++                borrowed, desc, /* useGles */ true, &borrowedFailureId);
++        const bool madeCurrent = gl && gl->MakeCurrent();
++        if (madeCurrent && gl->IsGLES() && gl->Version() >= 300) {
++          return gl.forget();
++        }
++        if (gl) {
++          borrowedFailureId =
++              "FEATURE_FAILURE_EGL_BORROWED_CONTEXT"_ns;
++          if (madeCurrent &&
++              !borrowed->fMakeCurrent(EGL_NO_SURFACE, EGL_NO_SURFACE,
++                                      EGL_NO_CONTEXT)) {
++            // Intentionally retain the context and borrowed wrapper so a
++            // later owned wrapper cannot collide with the still-current
++            // display.
++            *out_failureId = borrowedFailureId;
++            (void)gl.forget().take();
++            return nullptr;
++          }
++        }
++        gl = nullptr;
++        borrowed.reset();
++      }
++      gfxCriticalNote
++          << "Qt borrowed EGL display cannot provide a GLES 3 headless "
++             "context; using Gecko's display: "
++          << borrowedFailureId.get();
++    }
++  }
++#endif
++
+   const auto display = CreateDisplayForApp(*lib, false, out_failureId);
+   if (!display) {
+     return nullptr;
+diff --git a/gfx/gl/GLLibraryEGL.cpp b/gfx/gl/GLLibraryEGL.cpp
+index 158b13a017001..a9f0dd0e6255a 100644
+--- a/gfx/gl/GLLibraryEGL.cpp
++++ b/gfx/gl/GLLibraryEGL.cpp
+@@ -939,6 +939,16 @@ std::shared_ptr<EglDisplay> GLLibraryEGL::CreateBorrowedDisplay(
+   return ret;
+ }
+ 
++std::shared_ptr<EglDisplay> GLLibraryEGL::GetActiveDisplay(
++    const EGLDisplay display) {
++  StaticMutexAutoLock lock(sMutex);
++  const auto itr = mActiveDisplays.find(display);
++  if (itr == mActiveDisplays.end()) {
++    return nullptr;
++  }
++  return itr->second.lock();
++}
++
+ std::shared_ptr<EglDisplay> GLLibraryEGL::CreateDisplayLocked(
+     const bool forceAccel, nsACString* const out_failureId,
+     const StaticMutexAutoLock& aProofOfLock) {
+diff --git a/gfx/gl/GLLibraryEGL.h b/gfx/gl/GLLibraryEGL.h
+index 79273ea57f77c..4347a05746d0c 100644
+--- a/gfx/gl/GLLibraryEGL.h
++++ b/gfx/gl/GLLibraryEGL.h
+@@ -161,6 +161,7 @@ class GLLibraryEGL final {
+                                             nsACString* const out_failureId);
+   std::shared_ptr<EglDisplay> CreateBorrowedDisplay(
+       EGLDisplay display, nsACString* const out_failureId);
++  std::shared_ptr<EglDisplay> GetActiveDisplay(EGLDisplay display);
+   std::shared_ptr<EglDisplay> CreateDisplay(ID3D11Device*);
+   std::shared_ptr<EglDisplay> DefaultDisplay(nsACString* const out_failureId);
+ 
+diff --git a/gfx/gl/SharedSurfaceEGL.cpp b/gfx/gl/SharedSurfaceEGL.cpp
+index 85a45869b8dbf..cf57dc7bf7c55 100644
+--- a/gfx/gl/SharedSurfaceEGL.cpp
++++ b/gfx/gl/SharedSurfaceEGL.cpp
+@@ -25,9 +25,15 @@ namespace gl {
+ 
+ static bool HasEglImageExtensions(const GLContextEGL& gl) {
+   const auto& egl = *(gl.mEgl);
++#ifdef MOZ_WIDGET_QT
++  const bool allowDesktopGL =
++      egl.mOwnership == EglDisplay::Ownership::Borrowed;
++#else
++  const bool allowDesktopGL = true;
++#endif
+   return egl.HasKHRImageBase() &&
+          egl.IsExtensionSupported(EGLExtension::KHR_gl_texture_2D_image) &&
+-         (!gl.IsGLES() ||
++         ((allowDesktopGL && !gl.IsGLES()) ||
+           gl.IsExtensionSupported(GLContext::OES_EGL_image_external) ||
+           gl.IsExtensionSupported(GLContext::OES_EGL_image));
+ }

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -137,6 +137,9 @@ Patch81:     0081-Fix-Qt-form-control-theme-rendering.patch
 Patch82:     0082-Keep-about-support-snapshot-resilient-in-EmbedLite.patch
 Patch83:     0083-Register-gecko-camera-decoder-in-remote-video-paths.patch
 Patch84:     0084-Use-system-sqlite.patch
+Patch85:     0085-Support-Qt-EGL-display-on-Mesa.patch
+Patch86:     0086-Support-software-WebRender-on-EmbedLite.patch
+Patch87:     0087-Add-safe-Qt-display-fallback-for-hybris.patch
 
 BuildRequires:  rust >= 1.66.0
 BuildRequires:  rust-std-static


### PR DESCRIPTION
### Fix browser on non-hybris devices

Use Qt's borrowed EGLDisplay on Mesa for the direct EGLImage handoff. Force software WebRender when that display has no ES3-compatible EGL config, while retaining accelerated GLES presentation. Never replace Mesa's Qt display with an independent Gecko display.

Identify hybris from its EGL native-buffer extensions. Probe a borrowed GLES 3 context before selecting it for hardware WebRender. With no active wrapper, release a rejected probe before using Gecko's legacy owned display. If the context cannot be unbound, retain it and return failure to prevent an ownership-cache collision. Do not replace an active borrowed wrapper with an owned one.

Preserve legacy configuration on owned Qt displays and restrict desktop GL EGLImage sharing to borrowed Qt displays. Let EmbedLite reuse SingletonGL when a second borrowed GLES 3 context would not share WebRender shader objects.

Report focused failure IDs for borrowed display, config, surface, and context creation failures.

### Fix AV1 playback

Disable RDD (Remote Data Decoder) as it's not provided in EmbedLite and causes software playback of AV1 streams to fail.