### PR TITLE
[sailfishos][neterror] Restore certificate error handling. Fixes JB#64736

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -261,6 +261,9 @@ pref("dom.disable_window_find", true);
 // SSL error page behaviour
 pref("browser.ssl_override_behavior", 2);
 pref("browser.xul.error_pages.expert_bad_cert", false);
+pref("security.certerrors.mitm.priming.enabled", true);
+pref("security.certerrors.mitm.priming.endpoint", "https://mitmdetection.services.mozilla.com/");
+pref("security.certerrors.permanentOverride", true);
 
 // disable logging for the search service by default
 pref("browser.search.log", false);

--- a/rpm/0076-Fix-EmbedLite-toolkit-error-pages.patch
+++ b/rpm/0076-Fix-EmbedLite-toolkit-error-pages.patch
@@ -11,17 +11,23 @@ The network error page also needs to avoid Firefox chrome resources that are
 not packaged in EmbedLite, reload through the browsing context when there is no
 browser element, include a mobile viewport, and ship the toolkit Fluent brand
 strings used by the remote error document.
+
+Initialize certificate error actions before optional certificate details so a
+failure in embedder-specific detail collection cannot leave the page without
+navigation or certificate override controls.
 ---
- toolkit/actors/NetErrorChild.sys.mjs                 |  8 ++------
- toolkit/actors/NetErrorParent.sys.mjs                | 14 ++++++++++++--
- .../processsingleton/MainProcessSingleton.sys.mjs    |  5 +++++
- toolkit/content/aboutNetError.xhtml                  |  1 +
- toolkit/locales/en-US/chrome/branding/brand.ftl      |  9 +++++++++
- toolkit/locales/jar.mn                               |  1 +
- 6 files changed, 30 insertions(+), 8 deletions(-)
+ toolkit/actors/NetErrorChild.sys.mjs          |  8 +---
+ toolkit/actors/NetErrorParent.sys.mjs         | 48 ++++++++++++++-----
+ .../MainProcessSingleton.sys.mjs              |  5 ++
+ toolkit/content/aboutNetError.mjs             |  5 +-
+ toolkit/content/aboutNetError.xhtml           |  1 +
+ .../locales/en-US/chrome/branding/brand.ftl   |  9 ++++
+ toolkit/locales/jar.mn                        |  1 +
+ 7 files changed, 58 insertions(+), 19 deletions(-)
+ create mode 100644 toolkit/locales/en-US/chrome/branding/brand.ftl
 
 diff --git a/toolkit/actors/NetErrorChild.sys.mjs b/toolkit/actors/NetErrorChild.sys.mjs
-index 671eb22baa56..30a3181b5490 100644
+index 671eb22baa567..30a3181b5490b 100644
 --- a/toolkit/actors/NetErrorChild.sys.mjs
 +++ b/toolkit/actors/NetErrorChild.sys.mjs
 @@ -3,11 +3,7 @@
@@ -47,7 +53,7 @@ index 671eb22baa56..30a3181b5490 100644
  
    _getTRRSkipReason() {
 diff --git a/toolkit/actors/NetErrorParent.sys.mjs b/toolkit/actors/NetErrorParent.sys.mjs
-index 7d1f0f3f0fae..09eb392c9b81 100644
+index 7d1f0f3f0faed..f29fc8d68296b 100644
 --- a/toolkit/actors/NetErrorParent.sys.mjs
 +++ b/toolkit/actors/NetErrorParent.sys.mjs
 @@ -66,6 +66,16 @@ export class NetErrorParent extends JSWindowActorParent {
@@ -67,7 +73,40 @@ index 7d1f0f3f0fae..09eb392c9b81 100644
    hasChangedCertPrefs() {
      let prefSSLImpact = PREF_SSL_IMPACT_ROOTS.reduce((prefs, root) => {
        return prefs.concat(Services.prefs.getChildList(root));
-@@ -259,7 +269,7 @@ export class NetErrorParent extends JSWindowActorParent {
+@@ -143,18 +153,23 @@ export class NetErrorParent extends JSWindowActorParent {
+    * that has certificate errors, we can get them somewhere safe.
+    */
+   goBackFromErrorPage(browser) {
+-    if (!browser.canGoBack) {
++    let webNavigation = browser || this.browsingContext.top;
++    let canGoBack = browser
++      ? browser.canGoBack
++      : webNavigation.sessionHistory?.index > 0;
++
++    if (!canGoBack) {
+       // If the unsafe page is the first or the only one in history, go to the
+       // start page.
+-      browser.fixupAndLoadURIString(
+-        this.getDefaultHomePage(browser.ownerGlobal),
+-        {
+-          triggeringPrincipal:
+-            Services.scriptSecurityManager.getSystemPrincipal(),
+-        }
+-      );
++      let defaultPage = browser
++        ? this.getDefaultHomePage(browser.ownerGlobal)
++        : "about:blank";
++      webNavigation.fixupAndLoadURIString(defaultPage, {
++        triggeringPrincipal:
++          Services.scriptSecurityManager.getSystemPrincipal(),
++      });
+     } else {
+-      browser.goBack();
++      webNavigation.goBack();
+     }
+   }
+ 
+@@ -259,7 +274,7 @@ export class NetErrorParent extends JSWindowActorParent {
        case "Browser:EnableOnlineMode":
          // Reset network state and refresh the page.
          Services.io.offline = false;
@@ -76,7 +115,7 @@ index 7d1f0f3f0fae..09eb392c9b81 100644
          break;
        case "Browser:OpenCaptivePortalPage":
          this.browser.ownerGlobal.CaptivePortalWatcher.ensureCaptivePortalTab();
-@@ -278,7 +288,7 @@ export class NetErrorParent extends JSWindowActorParent {
+@@ -278,7 +293,7 @@ export class NetErrorParent extends JSWindowActorParent {
          for (let prefName of prefSSLImpact) {
            Services.prefs.clearUserPref(prefName);
          }
@@ -85,8 +124,26 @@ index 7d1f0f3f0fae..09eb392c9b81 100644
          break;
        case "Browser:SSLErrorGoBack":
          this.goBackFromErrorPage(this.browser);
+@@ -318,7 +333,16 @@ export class NetErrorParent extends JSWindowActorParent {
+             certsStringURL = certsStringURL.join("&");
+             let url = `about:certificate?${certsStringURL}`;
+ 
+-            let window = this.browser.ownerGlobal;
++            let browser = this.browser;
++            if (!browser) {
++              this.browsingContext.top.loadURI(Services.io.newURI(url), {
++                triggeringPrincipal:
++                  Services.scriptSecurityManager.getSystemPrincipal(),
++              });
++              break;
++            }
++
++            let window = browser.ownerGlobal;
+             if (AppConstants.MOZ_BUILD_APP === "browser") {
+               window.switchToTabHavingURI(url, true, {});
+             } else {
 diff --git a/toolkit/components/processsingleton/MainProcessSingleton.sys.mjs b/toolkit/components/processsingleton/MainProcessSingleton.sys.mjs
-index a10493f79b6b..738c68fcd275 100644
+index a10493f79b6bb..738c68fcd275f 100644
 --- a/toolkit/components/processsingleton/MainProcessSingleton.sys.mjs
 +++ b/toolkit/components/processsingleton/MainProcessSingleton.sys.mjs
 @@ -13,6 +13,11 @@ MainProcessSingleton.prototype = {
@@ -101,8 +158,31 @@ index a10493f79b6b..738c68fcd275 100644
          // Imported for side-effects.
          ChromeUtils.importESModule(
            "resource://gre/modules/CustomElementsListener.sys.mjs"
+diff --git a/toolkit/content/aboutNetError.mjs b/toolkit/content/aboutNetError.mjs
+index 943cf62244a3b..4b1dbcbcb2906 100644
+--- a/toolkit/content/aboutNetError.mjs
++++ b/toolkit/content/aboutNetError.mjs
+@@ -325,6 +325,10 @@ function initPage() {
+   const shortDesc = document.getElementById("errorShortDesc");
+ 
+   if (gIsCertError) {
++    // Keep the primary navigation and certificate override controls available
++    // even if collecting optional certificate details fails in an embedder.
++    initCertErrorPageActions();
++
+     const isStsError = window !== window.top || gHasSts;
+     const errArgs = { hostname: HOST_NAME };
+     if (isCaptive()) {
+@@ -352,7 +356,6 @@ function initPage() {
+       initPageCertError();
+     }
+ 
+-    initCertErrorPageActions();
+     setTechnicalDetailsOnCertError();
+     return;
+   }
 diff --git a/toolkit/content/aboutNetError.xhtml b/toolkit/content/aboutNetError.xhtml
-index 44bc72cecfbf..d0bc96f4d074 100644
+index 44bc72cecfbfd..d0bc96f4d0743 100644
 --- a/toolkit/content/aboutNetError.xhtml
 +++ b/toolkit/content/aboutNetError.xhtml
 @@ -9,6 +9,7 @@
@@ -115,7 +195,7 @@ index 44bc72cecfbf..d0bc96f4d074 100644
      <link rel="stylesheet" href="chrome://global/skin/aboutNetError.css" type="text/css" media="all" />
 diff --git a/toolkit/locales/en-US/chrome/branding/brand.ftl b/toolkit/locales/en-US/chrome/branding/brand.ftl
 new file mode 100644
-index 000000000000..083dda8cf853
+index 0000000000000..083dda8cf853e
 --- /dev/null
 +++ b/toolkit/locales/en-US/chrome/branding/brand.ftl
 @@ -0,0 +1,9 @@
@@ -129,7 +209,7 @@ index 000000000000..083dda8cf853
 +-brand-product-name = Sailfish Browser
 +-vendor-short-name = Jolla
 diff --git a/toolkit/locales/jar.mn b/toolkit/locales/jar.mn
-index 1f2189fd35f8..37ab0698ad62 100644
+index 1f2189fd35f88..37ab0698ad626 100644
 --- a/toolkit/locales/jar.mn
 +++ b/toolkit/locales/jar.mn
 @@ -4,6 +4,7 @@
@@ -140,5 +220,3 @@ index 1f2189fd35f8..37ab0698ad62 100644
    crashreporter                                    (%crashreporter/**/*.ftl)
    services                                         (%services/**/*.ftl)
    toolkit                                          (%toolkit/**/*.ftl)
--- 
-2.51.0

--- a/rpm/0088-Keep-certificate-error-controls-above-toolbar.patch
+++ b/rpm/0088-Keep-certificate-error-controls-above-toolbar.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Branson <andrew.branson@jolla.com>
+Date: Mon, 3 Aug 2026 20:25:57 +0200
+Subject: [sailfishos][neterror] Keep certificate controls above toolbar
+
+The toolkit page positions advanced panels absolutely. Because that
+position is excluded from the centered content height, Sailfish Browser's
+dynamic bottom toolbar can cover the certificate action row.
+
+Keep advanced panels in document flow while retaining their full viewport
+width. This leaves compact pages centered and reserves room for expanded
+certificate controls.
+---
+ toolkit/themes/shared/aboutNetError.css | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/toolkit/themes/shared/aboutNetError.css b/toolkit/themes/shared/aboutNetError.css
+index c84a72fce4a92..20656544f241c 100644
+--- a/toolkit/themes/shared/aboutNetError.css
++++ b/toolkit/themes/shared/aboutNetError.css
+@@ -100,10 +100,12 @@ button:disabled {
+   margin-top: 1.2em;
+ }
+ 
++/* EmbedLite's dynamic toolbar overlaps absolutely positioned content. Keep the
++ * advanced panels in the document flow so their controls remain visible. */
+ .advanced-panel-container {
+-  width: 100%;
+-  position: absolute;
+-  left: 0;
++  position: static;
++  width: 100vw;
++  margin-inline-start: calc((100% - 100vw) / 2);
+ }
+ 
+ .trr-message-container {

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -140,6 +140,7 @@ Patch84:     0084-Use-system-sqlite.patch
 Patch85:     0085-Support-Qt-EGL-display-on-Mesa.patch
 Patch86:     0086-Support-software-WebRender-on-EmbedLite.patch
 Patch87:     0087-Add-safe-Qt-display-fallback-for-hybris.patch
+Patch88:     0088-Keep-certificate-error-controls-above-toolbar.patch
 
 BuildRequires:  rust >= 1.66.0
 BuildRequires:  rust-std-static


### PR DESCRIPTION
Use ESR115 native certificate error handling through EmbedLite and initialize the toolkit actors it requires. Keep navigation, certificate inspection, and override actions functional without Firefox browser chrome.

Enable the ESR115 certificate-error preferences and keep expanded controls in document flow so the Browser toolbar cannot cover them.