### PR TITLE
[sailfishos][prompt] Allow beforeunload confirmation. Fixes JB#64866

### DIFF
--- a/embedding/embedlite/components/EmbedLitePromptCollection.sys.mjs
+++ b/embedding/embedlite/components/EmbedLitePromptCollection.sys.mjs
@@ -1,0 +1,190 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
+
+/**
+ * Implements nsIPromptCollection for EmbedLite.
+ */
+export class EmbedLitePromptCollection {
+  confirmRepost(browsingContext) {
+    let brandName;
+    try {
+      brandName = this.stringBundles.brand.GetStringFromName("brandShortName");
+    } catch (exception) {
+      // Use the generic prompt text when branding is unavailable.
+    }
+
+    let message;
+    let resendLabel;
+    try {
+      if (brandName) {
+        message = this.stringBundles.app.formatStringFromName(
+          "confirmRepostPrompt",
+          [brandName]
+        );
+      } else {
+        message = this.stringBundles.app.GetStringFromName(
+          "confirmRepostPrompt"
+        );
+      }
+      resendLabel =
+        this.stringBundles.app.GetStringFromName("resendButton.label");
+    } catch (exception) {
+      console.error("Failed to get strings from appstrings.properties");
+      return false;
+    }
+
+    let contentViewer = browsingContext?.docShell?.contentViewer;
+    let modalType = contentViewer?.isTabModalPromptAllowed
+      ? Ci.nsIPromptService.MODAL_TYPE_CONTENT
+      : Ci.nsIPromptService.MODAL_TYPE_WINDOW;
+    let buttonFlags =
+      (Ci.nsIPromptService.BUTTON_TITLE_IS_STRING *
+        Ci.nsIPromptService.BUTTON_POS_0) |
+      (Ci.nsIPromptService.BUTTON_TITLE_CANCEL *
+        Ci.nsIPromptService.BUTTON_POS_1);
+    let buttonPressed = Services.prompt.confirmExBC(
+      browsingContext,
+      modalType,
+      null,
+      message,
+      buttonFlags,
+      resendLabel,
+      null,
+      null,
+      null,
+      {}
+    );
+
+    return buttonPressed === 0;
+  }
+
+  async asyncBeforeUnloadCheck(browsingContext) {
+    let title;
+    let message;
+    let leaveLabel;
+    let stayLabel;
+
+    try {
+      title = this.stringBundles.dom.GetStringFromName("OnBeforeUnloadTitle");
+      message = this.stringBundles.dom.GetStringFromName(
+        "OnBeforeUnloadMessage2"
+      );
+      leaveLabel = this.stringBundles.dom.GetStringFromName(
+        "OnBeforeUnloadLeaveButton"
+      );
+      stayLabel = this.stringBundles.dom.GetStringFromName(
+        "OnBeforeUnloadStayButton"
+      );
+    } catch (exception) {
+      console.error("Failed to get strings from dom.properties");
+      return false;
+    }
+
+    let contentViewer = browsingContext?.docShell?.contentViewer;
+
+    if (
+      (contentViewer && !contentViewer.isTabModalPromptAllowed) ||
+      !browsingContext.ancestorsAreCurrent
+    ) {
+      console.error("Can't prompt from inactive content viewer");
+      return true;
+    }
+
+    let buttonFlags =
+      Ci.nsIPromptService.BUTTON_POS_0_DEFAULT |
+      (Ci.nsIPromptService.BUTTON_TITLE_IS_STRING *
+        Ci.nsIPromptService.BUTTON_POS_0) |
+      (Ci.nsIPromptService.BUTTON_TITLE_IS_STRING *
+        Ci.nsIPromptService.BUTTON_POS_1);
+
+    let result = await Services.prompt.asyncConfirmEx(
+      browsingContext,
+      Services.prompt.MODAL_TYPE_CONTENT,
+      title,
+      message,
+      buttonFlags,
+      leaveLabel,
+      stayLabel,
+      null,
+      null,
+      false,
+      { inPermitUnload: true }
+    );
+
+    return (
+      result.QueryInterface(Ci.nsIPropertyBag2).get("buttonNumClicked") == 0
+    );
+  }
+
+  confirmFolderUpload(browsingContext, directoryName) {
+    let title;
+    let message;
+    let acceptLabel;
+
+    try {
+      title = this.stringBundles.dom.GetStringFromName(
+        "FolderUploadPrompt.title"
+      );
+      message = this.stringBundles.dom.formatStringFromName(
+        "FolderUploadPrompt.message",
+        [directoryName]
+      );
+      acceptLabel = this.stringBundles.dom.GetStringFromName(
+        "FolderUploadPrompt.acceptButtonLabel"
+      );
+    } catch (exception) {
+      console.error("Failed to get strings from dom.properties");
+      return false;
+    }
+
+    let buttonFlags =
+      Services.prompt.BUTTON_TITLE_IS_STRING *
+        Services.prompt.BUTTON_POS_0 +
+      Services.prompt.BUTTON_TITLE_CANCEL * Services.prompt.BUTTON_POS_1 +
+      Services.prompt.BUTTON_POS_1_DEFAULT;
+
+    return (
+      Services.prompt.confirmExBC(
+        browsingContext,
+        Services.prompt.MODAL_TYPE_TAB,
+        title,
+        message,
+        buttonFlags,
+        acceptLabel,
+        null,
+        null,
+        null,
+        {}
+      ) === 0
+    );
+  }
+}
+
+const BUNDLES = {
+  dom: "chrome://global/locale/dom/dom.properties",
+  app: "chrome://global/locale/appstrings.properties",
+  brand: "chrome://branding/locale/brand.properties",
+};
+
+EmbedLitePromptCollection.prototype.stringBundles = {};
+
+for (const [bundleName, bundleUrl] of Object.entries(BUNDLES)) {
+  XPCOMUtils.defineLazyGetter(
+    EmbedLitePromptCollection.prototype.stringBundles,
+    bundleName,
+    function () {
+      let bundle = Services.strings.createBundle(bundleUrl);
+      if (!bundle) {
+        throw new Error("String bundle for prompt not present!");
+      }
+      return bundle;
+    }
+  );
+}
+
+EmbedLitePromptCollection.prototype.QueryInterface = ChromeUtils.generateQI([
+  "nsIPromptCollection",
+]);

--- a/embedding/embedlite/components/components.conf
+++ b/embedding/embedlite/components/components.conf
@@ -6,6 +6,12 @@
 
 Classes = [
     {
+        'cid': '{7c4ee3d8-8f68-4f8f-8d4a-49d2a6f6c1a0}',
+        'contract_ids': ['@mozilla.org/embedcomp/prompt-collection;1'],
+        'esModule': 'resource://gre/modules/EmbedLitePromptCollection.sys.mjs',
+        'constructor': 'EmbedLitePromptCollection',
+    },
+    {
         'cid': '{44596b9a-9dc7-4a4f-91e9-cc4bdce36dc8}',
         'contract_ids': ['@mozilla.org/widget/parent/clipboard;1'],
         'interfaces': ['nsIClipboard'],

--- a/embedding/embedlite/components/moz.build
+++ b/embedding/embedlite/components/moz.build
@@ -33,4 +33,8 @@ XPCOM_MANIFESTS += [
     'components.conf',
 ]
 
+EXTRA_JS_MODULES += [
+    'EmbedLitePromptCollection.sys.mjs',
+]
+
 FINAL_LIBRARY = 'xul'

--- a/embedding/embedlite/modules/EmbedLiteAppService.cpp
+++ b/embedding/embedlite/modules/EmbedLiteAppService.cpp
@@ -32,6 +32,7 @@
 #include "nsPIDOMWindow.h"
 #include "mozilla/AutoRestore.h"
 #include "mozilla/dom/ScriptSettings.h"
+#include "mozilla/dom/BrowsingContext.h"
 #include "mozilla/dom/EventTarget.h"
 
 using namespace mozilla;
@@ -105,6 +106,15 @@ void EmbedLiteAppService::RegisterView(uint32_t aId)
   EmbedLiteViewChildIface* view = sGetViewById(aId);
   NS_ENSURE_TRUE(view, );
   mIDMap[view->GetOuterID()] = aId;
+
+  nsCOMPtr<nsIWebBrowser> browser;
+  nsresult rv = view->GetBrowser(getter_AddRefs(browser));
+  NS_ENSURE_SUCCESS(rv, );
+  nsCOMPtr<nsIDocShell> docShell = do_GetInterface(browser);
+  NS_ENSURE_TRUE(docShell, );
+  RefPtr<dom::BrowsingContext> browsingContext = docShell->GetBrowsingContext();
+  NS_ENSURE_TRUE(browsingContext, );
+  mBrowserIDMap[browsingContext->Top()->BrowserId()] = aId;
 }
 
 void EmbedLiteAppService::UnregisterView(uint32_t aId)
@@ -113,6 +123,13 @@ void EmbedLiteAppService::UnregisterView(uint32_t aId)
   for (it = mIDMap.begin(); it != mIDMap.end(); ++it) {
     if (aId == it->second) {
       mIDMap.erase(it);
+      break;
+    }
+  }
+
+  for (it = mBrowserIDMap.begin(); it != mBrowserIDMap.end(); ++it) {
+    if (aId == it->second) {
+      mBrowserIDMap.erase(it);
       break;
     }
   }
@@ -137,6 +154,22 @@ EmbedLiteAppService::GetIDByWindow(mozIDOMWindowProxy* aWindow, uint32_t* aId)
   uint64_t OuterWindowID = 0;
   docShell->GetOuterWindowID(&OuterWindowID);
   *aId = mIDMap[OuterWindowID];
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+EmbedLiteAppService::GetIDByBrowsingContext(dom::BrowsingContext* aBrowsingContext,
+                                             uint32_t* aId)
+{
+  NS_ENSURE_ARG_POINTER(aBrowsingContext);
+  NS_ENSURE_ARG_POINTER(aId);
+
+  auto it = mBrowserIDMap.find(aBrowsingContext->Top()->BrowserId());
+  if (it == mBrowserIDMap.end()) {
+    return NS_ERROR_NOT_AVAILABLE;
+  }
+
+  *aId = it->second;
   return NS_OK;
 }
 

--- a/embedding/embedlite/modules/EmbedLiteAppService.h
+++ b/embedding/embedlite/modules/EmbedLiteAppService.h
@@ -37,6 +37,7 @@ protected:
 private:
   friend class EmbedLiteJSON;
   std::map<uint64_t, uint32_t> mIDMap;
+  std::map<uint64_t, uint32_t> mBrowserIDMap;
   typedef nsClassHashtable<nsCStringHashKey, nsTArray<nsCOMPtr<nsIEmbedMessageListener> > > MsgListenersArray;
   MsgListenersArray mMessageListeners;
   bool mHandlingMessages;
@@ -53,4 +54,3 @@ private:
 
 
 #endif /* EmbedLiteAppService_H_ */
-

--- a/embedding/embedlite/modules/nsIEmbedAppService.idl
+++ b/embedding/embedlite/modules/nsIEmbedAppService.idl
@@ -8,6 +8,7 @@
 #include "nsIBaseWindow.idl"
 #include "nsIWebBrowser.idl"
 webidl EventTarget;
+webidl BrowsingContext;
 
 /**
  * An optional interface for embedding clients wishing to receive
@@ -25,11 +26,14 @@ interface nsIEmbedMessageListener : nsISupports
     void onMessageReceived(in string messageName, in wstring message);
 };
 
-[scriptable, uuid(3c61976a-710b-11e2-a4a0-1354c757920d)]
+[scriptable, uuid(5ef6fb02-68cd-4bf8-b2b1-1a469bb01937)]
 interface nsIEmbedAppService : nsISupports
 {
     // Get Embed View ID by DOMWindow
     void getIDByWindow(in mozIDOMWindowProxy aWindow, [retval] out uint32_t aId);
+    // Get Embed View ID by BrowsingContext
+    void getIDByBrowsingContext(in BrowsingContext aBrowsingContext,
+                                [retval] out uint32_t aId);
     // Send JSON Message to Embed View with related View ID
     void sendAsyncMessage(in uint32_t aId, in wstring messageName, in wstring message);
     void sendSyncMessage(in uint32_t aId, in wstring messageName, in wstring message,

--- a/rpm/0089-Allow-EmbedLite-beforeunload-confirmation.patch
+++ b/rpm/0089-Allow-EmbedLite-beforeunload-confirmation.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Branson <andrew.branson@jolla.com>
+Date: Mon, 10 Aug 2026 09:24:57 +0200
+Subject: [sailfishos][prompt] Allow EmbedLite confirmEx dialogs
+
+ESR115 uses nsIPromptCollection and asyncConfirmEx for beforeunload
+confirmation. Route confirmEx through the existing EmbedLite confirm bridge
+so the native UI can return a navigation decision.
+
+Resolve the owning EmbedLite view from the BrowsingContext because the async
+parent-process check has no content DOM window. Match responses to that view
+and preserve the explicit permit-unload marker while dispatching the modal
+dialog event.
+
+Expose that marker in the native UI payload so the dialog bridge can defer its
+reply until the PageStack has finished dismissing the beforeunload dialog.
+---
+ .../components/prompts/src/Prompter.sys.mjs   | 20 ++++++-------------
+ 1 file changed, 6 insertions(+), 14 deletions(-)
+
+diff --git a/toolkit/components/prompts/src/Prompter.sys.mjs b/toolkit/components/prompts/src/Prompter.sys.mjs
+index b054a849e3c66..23e18060df638 100644
+--- a/toolkit/components/prompts/src/Prompter.sys.mjs
++++ b/toolkit/components/prompts/src/Prompter.sys.mjs
+@@ -1089,6 +1089,7 @@ class ModalPrompter {
+         break;
+       case "confirm":
+       case "confirmCheck":
++      case "confirmEx":
+         topic = "embed:confirm";
+         responseTopic = "confirmresponse";
+         break;
+@@ -1114,20 +1115,9 @@ class ModalPrompter {
+       return false;
+     }
+ 
+-    let win;
+-    try {
+-      win = this.browsingContext.top?.window || this.browsingContext.window;
+-    } catch (e) {
+-      return false;
+-    }
+-
+-    if (!win) {
+-      return false;
+-    }
+-
+     let winId;
+     try {
+-      winId = embedService.getIDByWindow(win);
++      winId = embedService.getIDByBrowsingContext(this.browsingContext);
+     } catch (e) {
+       return false;
+     }
+@@ -1140,6 +1130,7 @@ class ModalPrompter {
+       winId,
+       title: args.title,
+       text: args.text,
++      inPermitUnload: !!args.inPermitUnload,
+       inputs: [],
+     };
+ 
+@@ -1191,7 +1182,7 @@ class ModalPrompter {
+ 
+     let closed = false;
+     let handleResponse = response => {
+-      if (closed) {
++      if (closed || response.winId !== winId) {
+         return;
+       }
+ 
+@@ -1240,7 +1231,8 @@ class ModalPrompter {
+     if (promptWindow) {
+       try {
+         let docShell = this.browsingContext.docShell;
+-        let inPermitUnload = docShell?.contentViewer?.inPermitUnload;
++        let inPermitUnload =
++          args.inPermitUnload || docShell?.contentViewer?.inPermitUnload;
+         args.inPermitUnload = inPermitUnload;
+         PromptUtils.fireDialogEvent(
+           promptWindow,

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -141,6 +141,7 @@ Patch85:     0085-Support-Qt-EGL-display-on-Mesa.patch
 Patch86:     0086-Support-software-WebRender-on-EmbedLite.patch
 Patch87:     0087-Add-safe-Qt-display-fallback-for-hybris.patch
 Patch88:     0088-Keep-certificate-error-controls-above-toolbar.patch
+Patch89:     0089-Allow-EmbedLite-beforeunload-confirmation.patch
 
 BuildRequires:  rust >= 1.66.0
 BuildRequires:  rust-std-static


### PR DESCRIPTION
ESR115 asks nsIPromptCollection asynchronously before leaving a page. Add an EmbedLite implementation that routes confirmation through the native prompt bridge.

Map parent-process BrowsingContexts to their owning EmbedLite views and correlate responses by view ID.

This new contract is also used for reminders about re-submitting POST forms and directory upload confirmation, so those should work now too.